### PR TITLE
Add one-month StockForecastModel, stock-universe downloader, standalone example and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,63 @@ python setup.py install
 
 Make sure to use TICKER symbol from yahoo finance website
 https://in.finance.yahoo.com/ 
+
+## Forecast model example (Gradient Boosting)
+
+```python
+from yahoo_finance_api import StockForecastModel
+
+model = StockForecastModel(
+    stock_ticker="AAPL",
+    market_cap_usd=2_900_000_000_000,
+    category_label="technology"
+)
+
+artifacts = model.train()
+print("MAE:", artifacts.mae)
+print("R2:", artifacts.r2)
+print("Predicted next 1-month change:", model.predict_latest())
+```
+
+The model uses daily OHLCV, 20/120/200-day moving averages, price-weighted
+volume for 1-week and 1-month windows, weekly gold and VIX changes, and a
+large-cap (>10B) indicator with stock category encoding.
+
+
+You can also visualize historical trend with MA5, MA20, MA120:
+
+```python
+model.load_raw_data()
+ax = model.plot_historical_trend(window_size=250)
+```
+
+
+Backtest (walk-forward, predicted vs actual 1-month return):
+
+```python
+bt = model.backtest_predictions(min_train_size=252, step=1)
+ax = model.plot_backtest(min_train_size=252, step=1)
+```
+
+
+## Download latest stock list to CSV
+
+```python
+from yahoo_finance_api import download_stock_list_to_csv
+
+df = download_stock_list_to_csv("latest_us_stock_list.csv")
+print(df.head())
+```
+
+This CSV includes stock symbol list, exchange, market cap (market size), and stock category (sector).
+
+
+Use different metadata providers:
+
+```python
+# Yahoo (default)
+df = download_stock_list_to_csv("latest_us_stock_list.csv", metadata_source="yahoo")
+
+# Financial Modeling Prep (recommended fallback)
+df = download_stock_list_to_csv("latest_us_stock_list.csv", metadata_source="fmp", fmp_api_key="YOUR_KEY")
+```

--- a/standalone_stock_forecast/README.md
+++ b/standalone_stock_forecast/README.md
@@ -1,0 +1,70 @@
+# Standalone Stock Forecast Model
+
+This folder is structured so you can copy it into a **new GitHub repository** and run it independently.
+
+## What it does
+- Downloads daily OHLCV stock data from Yahoo Finance.
+- Builds engineered features:
+  - 20/120/200-day moving averages
+  - price-weighted volume + 1-week / 1-month rolling averages
+  - 1-week / 1-month momentum
+  - weekly gold change
+  - weekly VIX change
+  - stock category (one-hot encoded)
+  - market cap bucket (>10B)
+- Trains a **GradientBoostingRegressor** to predict the next 1-month (21 trading days) return.
+- Includes historical trend plotting with MA5, MA20, and MA120 lines.
+
+## Project structure
+- `yahoo_client.py` - lightweight Yahoo chart API downloader
+- `forecast_model.py` - feature engineering + training/inference code
+- `train_example.py` - runnable example
+- `requirements.txt` - Python dependencies
+- `stock_list_downloader.py` - download latest stock list + market cap + category to CSV
+
+## Quick start
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python train_example.py
+```
+
+## Move to a new repo
+1. Create a new empty GitHub repo.
+2. Copy all files from `standalone_stock_forecast/` into that repo root.
+3. Commit and push.
+
+
+## Plot historical trend
+```python
+from forecast_model import StockForecastModel
+
+model = StockForecastModel("AAPL", 2_900_000_000_000, "technology")
+model.load_raw_data()
+ax = model.plot_historical_trend(window_size=250)
+```
+
+
+## Backtest historical forecasts
+```python
+bt = model.backtest_predictions(min_train_size=252, step=1)
+ax = model.plot_backtest(min_train_size=252, step=1)
+```
+
+
+## Download latest stock list CSV
+```bash
+python stock_list_downloader.py
+```
+
+
+Use different metadata providers:
+
+```python
+# Yahoo (default)
+df = download_stock_list_to_csv("latest_us_stock_list.csv", metadata_source="yahoo")
+
+# Financial Modeling Prep (recommended fallback)
+df = download_stock_list_to_csv("latest_us_stock_list.csv", metadata_source="fmp", fmp_api_key="YOUR_KEY")
+```

--- a/standalone_stock_forecast/forecast_model.py
+++ b/standalone_stock_forecast/forecast_model.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from typing import Optional
+
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.metrics import mean_absolute_error, r2_score
+from sklearn.model_selection import train_test_split
+
+from yahoo_client import YahooFinanceClient
+
+
+@dataclass
+class ModelArtifacts:
+    model: GradientBoostingRegressor
+    feature_columns: list[str]
+    mae: float
+    r2: float
+
+
+class StockForecastModel:
+    def __init__(
+        self,
+        stock_ticker: str,
+        market_cap_usd: float,
+        category_label: str,
+        history_range: str = "5y",
+    ) -> None:
+        self.stock_ticker = stock_ticker
+        self.market_cap_usd = market_cap_usd
+        self.category_label = category_label
+        self.history_range = history_range
+        self.data: Optional[pd.DataFrame] = None
+        self.artifacts: Optional[ModelArtifacts] = None
+
+    def load_raw_data(self) -> pd.DataFrame:
+        stock = YahooFinanceClient(self.stock_ticker, self.history_range, "1d").fetch()
+        gold = YahooFinanceClient("GC=F", self.history_range, "1d").fetch()
+        vix = YahooFinanceClient("^VIX", self.history_range, "1d").fetch()
+
+        df = stock[["Open", "High", "Low", "Close", "Volume"]].copy()
+        df["gold_close"] = gold["Close"].reindex(df.index).ffill()
+        df["vix_close"] = vix["Close"].reindex(df.index).ffill()
+        self.data = df.dropna()
+        return self.data
+
+    def build_features(self) -> pd.DataFrame:
+        if self.data is None:
+            self.load_raw_data()
+
+        df = self.data.copy()
+        df["ma_20"] = df["Close"].rolling(20).mean()
+        df["ma_120"] = df["Close"].rolling(120).mean()
+        df["ma_200"] = df["Close"].rolling(200).mean()
+
+        df["price_weighted_volume"] = df["Close"] * df["Volume"]
+        df["pwv_1w"] = df["price_weighted_volume"].rolling(5).mean()
+        df["pwv_1m"] = df["price_weighted_volume"].rolling(21).mean()
+
+        df["change_1w"] = df["Close"].pct_change(5)
+        df["change_1m"] = df["Close"].pct_change(21)
+        df["gold_change_1w"] = df["gold_close"].pct_change(5)
+        df["vix_change_1w"] = df["vix_close"].pct_change(5)
+
+        df["stock_category"] = self.category_label
+        df["is_large_cap_10b"] = float(self.market_cap_usd > 10_000_000_000)
+
+        df["target_1m_price_change"] = df["Close"].shift(-21) / df["Close"] - 1
+        df = pd.get_dummies(df, columns=["stock_category"], drop_first=False)
+
+        feature_cols = [
+            "Open", "High", "Low", "Close", "Volume", "ma_20", "ma_120", "ma_200",
+            "pwv_1w", "pwv_1m", "change_1w", "change_1m", "gold_change_1w", "vix_change_1w",
+            "is_large_cap_10b",
+        ] + [c for c in df.columns if c.startswith("stock_category_")]
+
+        self.data = df[feature_cols + ["target_1m_price_change"]].dropna()
+        return self.data
+
+
+    def plot_historical_trend(self, window_size: int = 180):
+        """Plot historical close trend with MA5/MA20/MA120."""
+        if self.data is None:
+            self.load_raw_data()
+
+        base = self.data[["Close"]].copy()
+        base["MA5"] = base["Close"].rolling(5).mean()
+        base["MA20"] = base["Close"].rolling(20).mean()
+        base["MA120"] = base["Close"].rolling(120).mean()
+
+        plot_df = base.tail(window_size).dropna()
+        ax = plot_df[["Close", "MA5", "MA20", "MA120"]].plot(
+            figsize=(12, 6),
+            title=f"{self.stock_ticker} Historical Trend (last {window_size} periods)"
+        )
+        ax.set_xlabel("Date")
+        ax.set_ylabel("Price")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def train(self, random_state: int = 42) -> ModelArtifacts:
+        if self.data is None or "target_1m_price_change" not in self.data.columns:
+            self.build_features()
+
+        X = self.data.drop(columns=["target_1m_price_change"])
+        y = self.data["target_1m_price_change"]
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
+
+        model = GradientBoostingRegressor(random_state=random_state)
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+
+        self.artifacts = ModelArtifacts(
+            model=model,
+            feature_columns=list(X.columns),
+            mae=float(mean_absolute_error(y_test, preds)),
+            r2=float(r2_score(y_test, preds)),
+        )
+        return self.artifacts
+
+    def backtest_predictions(self, min_train_size: int = 252, step: int = 1) -> pd.DataFrame:
+        """Walk-forward backtest: predict next 1-month return for each day.
+
+        Uses only historical data available up to each forecast date, then compares
+        with the realized 1-month forward return.
+        """
+        if self.data is None or "target_1m_price_change" not in self.data.columns:
+            self.build_features()
+
+        df = self.data.copy()
+        X_all = df.drop(columns=["target_1m_price_change"])
+        y_all = df["target_1m_price_change"]
+
+        records = []
+        model = GradientBoostingRegressor(random_state=42)
+
+        for i in range(min_train_size, len(df), step):
+            X_train = X_all.iloc[:i]
+            y_train = y_all.iloc[:i]
+            X_test = X_all.iloc[[i]]
+
+            model.fit(X_train, y_train)
+            pred = float(model.predict(X_test)[0])
+            actual = float(y_all.iloc[i])
+
+            records.append({
+                "date": df.index[i],
+                "predicted_1m_change": pred,
+                "actual_1m_change": actual,
+            })
+
+        backtest_df = pd.DataFrame(records).set_index("date")
+        backtest_df["prediction_error"] = backtest_df["predicted_1m_change"] - backtest_df["actual_1m_change"]
+        return backtest_df
+
+    def plot_backtest(self, min_train_size: int = 252, step: int = 1):
+        """Plot historical backtest with predicted vs actual 1-month return."""
+        backtest_df = self.backtest_predictions(min_train_size=min_train_size, step=step)
+        ax = backtest_df[["actual_1m_change", "predicted_1m_change"]].plot(
+            figsize=(12, 6),
+            title=f"{self.stock_ticker} Backtest: Actual vs Predicted 1-Month Change"
+        )
+        ax.set_xlabel("Date")
+        ax.set_ylabel("1-Month Return")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def predict_latest(self) -> float:
+        if self.artifacts is None:
+            raise RuntimeError("Train model first.")
+        latest = self.data[self.artifacts.feature_columns].tail(1)
+        return float(self.artifacts.model.predict(latest)[0])

--- a/standalone_stock_forecast/requirements.txt
+++ b/standalone_stock_forecast/requirements.txt
@@ -1,0 +1,5 @@
+pandas>=2.0.0
+numpy>=1.24.0
+requests>=2.28.0
+scikit-learn>=1.3.0
+matplotlib>=3.7.0

--- a/standalone_stock_forecast/stock_list_downloader.py
+++ b/standalone_stock_forecast/stock_list_downloader.py
@@ -1,0 +1,14 @@
+import os
+
+from yahoo_finance_api.stock_universe import download_stock_list_to_csv
+
+
+if __name__ == "__main__":
+    source = os.getenv("STOCK_META_SOURCE", "yahoo")
+    fmp_key = os.getenv("FMP_API_KEY")
+    df = download_stock_list_to_csv(
+        output_csv="latest_us_stock_list.csv",
+        metadata_source=source,
+        fmp_api_key=fmp_key,
+    )
+    print(f"Saved {len(df)} rows to latest_us_stock_list.csv using source={source}")

--- a/standalone_stock_forecast/train_example.py
+++ b/standalone_stock_forecast/train_example.py
@@ -1,0 +1,18 @@
+from forecast_model import StockForecastModel
+
+
+if __name__ == "__main__":
+    model = StockForecastModel(
+        stock_ticker="AAPL",
+        market_cap_usd=2_900_000_000_000,
+        category_label="technology",
+        history_range="5y",
+    )
+
+    artifacts = model.train()
+    prediction = model.predict_latest()
+
+    print("Model trained successfully")
+    print("MAE:", artifacts.mae)
+    print("R2:", artifacts.r2)
+    print("Predicted 1-month forward return:", prediction)

--- a/standalone_stock_forecast/yahoo_client.py
+++ b/standalone_stock_forecast/yahoo_client.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import time as _time
+
+import pandas as pd
+import requests
+
+
+class YahooFinanceClient:
+    def __init__(self, ticker: str, result_range: str = "1y", interval: str = "1d") -> None:
+        self.ticker = ticker
+        self.result_range = result_range
+        self.interval = interval
+
+    def fetch(self) -> pd.DataFrame:
+        headers = {"User-Agent": "Mozilla/5.0"}
+        params = {"range": self.result_range, "interval": self.interval}
+        url = f"https://query1.finance.yahoo.com/v8/finance/chart/{self.ticker}"
+
+        response = requests.get(url=url, params=params, headers=headers, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+
+        error = data["chart"]["error"]
+        if error:
+            raise ValueError(error["description"])
+
+        result = data["chart"]["result"][0]
+        timestamps = result["timestamp"]
+        quote = result["indicators"]["quote"][0]
+
+        index = [_time.strftime("%Y-%m-%d", _time.localtime(ts)) for ts in timestamps]
+        df = pd.DataFrame(
+            {
+                "Open": quote["open"],
+                "High": quote["high"],
+                "Low": quote["low"],
+                "Close": quote["close"],
+                "Volume": quote["volume"],
+            },
+            index=pd.to_datetime(index),
+        )
+
+        return df.dropna()

--- a/yahoo_finance_api/__init__.py
+++ b/yahoo_finance_api/__init__.py
@@ -84,3 +84,7 @@ class YahooFinance:
     def to_csv(self, file_name):
         self.result.to_csv(file_name)
 
+
+from .forecast_model import ModelArtifacts, StockForecastModel, build_multi_stock_dataset
+
+from .stock_universe import download_stock_list_to_csv, fetch_us_stock_symbols, enrich_with_yahoo_metadata, enrich_with_fmp_metadata

--- a/yahoo_finance_api/forecast_model.py
+++ b/yahoo_finance_api/forecast_model.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.metrics import mean_absolute_error, r2_score
+from sklearn.model_selection import train_test_split
+
+from . import YahooFinance
+
+
+@dataclass
+class ModelArtifacts:
+    model: GradientBoostingRegressor
+    feature_columns: list[str]
+    train_rows: int
+    test_rows: int
+    mae: float
+    r2: float
+
+
+class StockForecastModel:
+    """Build a one-month stock price-change forecasting model.
+
+    Features include moving averages, price-weighted volume aggregates,
+    one-week and one-month momentum, and external market features from
+    gold and VIX weekly changes.
+    """
+
+    def __init__(
+        self,
+        stock_ticker: str,
+        market_cap_usd: float,
+        category_label: str,
+        history_range: str = "5y",
+    ) -> None:
+        self.stock_ticker = stock_ticker
+        self.market_cap_usd = market_cap_usd
+        self.category_label = category_label
+        self.history_range = history_range
+        self.data: Optional[pd.DataFrame] = None
+        self.artifacts: Optional[ModelArtifacts] = None
+
+    def load_raw_data(self) -> pd.DataFrame:
+        stock = YahooFinance(self.stock_ticker, result_range=self.history_range, interval="1d").result
+        gold = YahooFinance("GC=F", result_range=self.history_range, interval="1d").result
+        vix = YahooFinance("^VIX", result_range=self.history_range, interval="1d").result
+
+        df = stock[["Open", "High", "Low", "Close", "Volume"]].copy()
+        df["gold_close"] = gold["Close"].reindex(df.index).ffill()
+        df["vix_close"] = vix["Close"].reindex(df.index).ffill()
+        self.data = df.dropna().copy()
+        return self.data
+
+    def build_features(self) -> pd.DataFrame:
+        if self.data is None:
+            self.load_raw_data()
+
+        df = self.data.copy()
+        df["ma_20"] = df["Close"].rolling(20).mean()
+        df["ma_120"] = df["Close"].rolling(120).mean()
+        df["ma_200"] = df["Close"].rolling(200).mean()
+
+        df["price_weighted_volume"] = df["Close"] * df["Volume"]
+        df["pwv_1w"] = df["price_weighted_volume"].rolling(5).mean()
+        df["pwv_1m"] = df["price_weighted_volume"].rolling(21).mean()
+
+        df["change_1w"] = df["Close"].pct_change(5)
+        df["change_1m"] = df["Close"].pct_change(21)
+        df["gold_change_1w"] = df["gold_close"].pct_change(5)
+        df["vix_change_1w"] = df["vix_close"].pct_change(5)
+
+        df["stock_category"] = self.category_label
+        df["is_large_cap_10b"] = float(self.market_cap_usd > 10_000_000_000)
+
+        df["target_1m_price_change"] = df["Close"].shift(-21) / df["Close"] - 1
+        df = pd.get_dummies(df, columns=["stock_category"], drop_first=False)
+
+        feature_cols = [
+            "Open",
+            "High",
+            "Low",
+            "Close",
+            "Volume",
+            "ma_20",
+            "ma_120",
+            "ma_200",
+            "pwv_1w",
+            "pwv_1m",
+            "change_1w",
+            "change_1m",
+            "gold_change_1w",
+            "vix_change_1w",
+            "is_large_cap_10b",
+        ] + [c for c in df.columns if c.startswith("stock_category_")]
+
+        engineered = df[feature_cols + ["target_1m_price_change"]].dropna()
+        self.data = engineered
+        return engineered
+
+
+    def plot_historical_trend(self, window_size: int = 180):
+        """Plot historical close trend with MA5/MA20/MA120.
+
+        :param window_size: Number of most recent rows to plot.
+        :return: matplotlib Axes object
+        """
+        if self.data is None:
+            self.load_raw_data()
+
+        base = self.data[["Close"]].copy()
+        base["MA5"] = base["Close"].rolling(5).mean()
+        base["MA20"] = base["Close"].rolling(20).mean()
+        base["MA120"] = base["Close"].rolling(120).mean()
+        plot_df = base.tail(window_size).dropna()
+
+        ax = plot_df[["Close", "MA5", "MA20", "MA120"]].plot(
+            figsize=(12, 6),
+            title=f"{self.stock_ticker} Historical Trend (last {window_size} periods)"
+        )
+        ax.set_xlabel("Date")
+        ax.set_ylabel("Price")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def train(self, random_state: int = 42) -> ModelArtifacts:
+        if self.data is None or "target_1m_price_change" not in self.data.columns:
+            self.build_features()
+
+        df = self.data.copy()
+        X = df.drop(columns=["target_1m_price_change"])
+        y = df["target_1m_price_change"]
+
+        X_train, X_test, y_train, y_test = train_test_split(
+            X,
+            y,
+            test_size=0.2,
+            random_state=random_state,
+            shuffle=False,
+        )
+
+        model = GradientBoostingRegressor(random_state=random_state)
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+
+        artifacts = ModelArtifacts(
+            model=model,
+            feature_columns=list(X.columns),
+            train_rows=len(X_train),
+            test_rows=len(X_test),
+            mae=float(mean_absolute_error(y_test, preds)),
+            r2=float(r2_score(y_test, preds)),
+        )
+        self.artifacts = artifacts
+        return artifacts
+
+    def backtest_predictions(self, min_train_size: int = 252, step: int = 1) -> pd.DataFrame:
+        """Walk-forward backtest: predict next 1-month return for each day.
+
+        Uses only historical data available up to each forecast date, then compares
+        with the realized 1-month forward return.
+        """
+        if self.data is None or "target_1m_price_change" not in self.data.columns:
+            self.build_features()
+
+        df = self.data.copy()
+        X_all = df.drop(columns=["target_1m_price_change"])
+        y_all = df["target_1m_price_change"]
+
+        records = []
+        model = GradientBoostingRegressor(random_state=42)
+
+        for i in range(min_train_size, len(df), step):
+            X_train = X_all.iloc[:i]
+            y_train = y_all.iloc[:i]
+            X_test = X_all.iloc[[i]]
+
+            model.fit(X_train, y_train)
+            pred = float(model.predict(X_test)[0])
+            actual = float(y_all.iloc[i])
+
+            records.append({
+                "date": df.index[i],
+                "predicted_1m_change": pred,
+                "actual_1m_change": actual,
+            })
+
+        backtest_df = pd.DataFrame(records).set_index("date")
+        backtest_df["prediction_error"] = backtest_df["predicted_1m_change"] - backtest_df["actual_1m_change"]
+        return backtest_df
+
+    def plot_backtest(self, min_train_size: int = 252, step: int = 1):
+        """Plot historical backtest with predicted vs actual 1-month return."""
+        backtest_df = self.backtest_predictions(min_train_size=min_train_size, step=step)
+        ax = backtest_df[["actual_1m_change", "predicted_1m_change"]].plot(
+            figsize=(12, 6),
+            title=f"{self.stock_ticker} Backtest: Actual vs Predicted 1-Month Change"
+        )
+        ax.set_xlabel("Date")
+        ax.set_ylabel("1-Month Return")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def predict_latest(self) -> float:
+        if self.artifacts is None:
+            raise RuntimeError("Call train() before predict_latest().")
+
+        latest = self.data[self.artifacts.feature_columns].tail(1)
+        return float(self.artifacts.model.predict(latest)[0])
+
+
+def build_multi_stock_dataset(configs: Iterable[dict], history_range: str = "5y") -> pd.DataFrame:
+    """Create a combined dataset across several stocks in the same category schema.
+
+    Each config should include: ticker, market_cap_usd, category_label.
+    """
+
+    frames: list[pd.DataFrame] = []
+    for cfg in configs:
+        model = StockForecastModel(
+            stock_ticker=cfg["ticker"],
+            market_cap_usd=float(cfg["market_cap_usd"]),
+            category_label=cfg["category_label"],
+            history_range=history_range,
+        )
+        frames.append(model.build_features())
+
+    return pd.concat(frames, axis=0).dropna()

--- a/yahoo_finance_api/stock_universe.py
+++ b/yahoo_finance_api/stock_universe.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Iterable
+
+import pandas as pd
+import requests
+
+NASDAQ_LISTED_URL = "https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt"
+OTHER_LISTED_URL = "https://www.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt"
+YAHOO_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
+FMP_PROFILE_URL = "https://financialmodelingprep.com/api/v3/profile"
+
+
+def _read_symbol_file(url: str, symbol_col: str) -> pd.DataFrame:
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    lines = [line.strip() for line in response.text.splitlines() if line.strip()]
+    header = lines[0].split("|")
+    rows = [line.split("|") for line in lines[1:] if not line.startswith("File Creation Time")]
+    return pd.DataFrame(rows, columns=header)
+
+
+def fetch_us_stock_symbols() -> pd.DataFrame:
+    """Fetch a broad US stock symbol list from NASDAQ Trader directories."""
+    nasdaq = _read_symbol_file(NASDAQ_LISTED_URL, "Symbol")
+    nasdaq = nasdaq.rename(columns={"Symbol": "symbol", "Security Name": "security_name"})
+    nasdaq["exchange"] = "NASDAQ"
+
+    other = _read_symbol_file(OTHER_LISTED_URL, "ACT Symbol")
+    other = other.rename(columns={"ACT Symbol": "symbol", "Security Name": "security_name", "Exchange": "exchange"})
+
+    combined = pd.concat([
+        nasdaq[["symbol", "security_name", "exchange"]],
+        other[["symbol", "security_name", "exchange"]],
+    ], ignore_index=True)
+    combined = combined[~combined["symbol"].str.contains(r"\$", regex=True, na=False)]
+    return combined.drop_duplicates(subset=["symbol"]).reset_index(drop=True)
+
+
+def _chunks(items: Iterable[str], size: int):
+    items = list(items)
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+def _safe_fetch_yahoo_batch(batch: list[str], headers: dict, retries: int = 3) -> list[dict]:
+    params = {"symbols": ",".join(batch)}
+    delay = 1.0
+    for attempt in range(retries):
+        try:
+            response = requests.get(YAHOO_QUOTE_URL, params=params, headers=headers, timeout=30)
+            if response.status_code == 401:
+                return []
+            response.raise_for_status()
+            return response.json().get("quoteResponse", {}).get("result", [])
+        except requests.RequestException:
+            if attempt == retries - 1:
+                return []
+            time.sleep(delay)
+            delay *= 2
+    return []
+
+
+def enrich_with_yahoo_metadata(symbols_df: pd.DataFrame, batch_size: int = 200) -> pd.DataFrame:
+    records = []
+    headers = {"User-Agent": "Mozilla/5.0"}
+    for batch in _chunks(symbols_df["symbol"].tolist(), batch_size):
+        result = _safe_fetch_yahoo_batch(batch, headers=headers)
+        if not result and len(batch) > 1:
+            for sym in batch:
+                one = _safe_fetch_yahoo_batch([sym], headers=headers)
+                if one:
+                    result.extend(one)
+                time.sleep(0.05)
+        for item in result:
+            records.append({
+                "symbol": item.get("symbol"),
+                "market_cap": item.get("marketCap"),
+                "sector": item.get("sector"),
+                "industry": item.get("industry"),
+                "quote_type": item.get("quoteType"),
+                "meta_source": "yahoo",
+            })
+
+    meta = pd.DataFrame(records).drop_duplicates(subset=["symbol"]) if records else pd.DataFrame(columns=["symbol", "market_cap", "sector", "industry", "quote_type", "meta_source"])
+    merged = symbols_df.merge(meta, on="symbol", how="left")
+    merged["stock_category"] = merged["sector"].fillna("Unknown")
+    return merged
+
+
+def enrich_with_fmp_metadata(symbols_df: pd.DataFrame, api_key: str | None = None, batch_size: int = 100) -> pd.DataFrame:
+    """Add market cap and category from Financial Modeling Prep profiles API."""
+    resolved_key = api_key or os.getenv("FMP_API_KEY")
+    if not resolved_key:
+        raise ValueError("FMP API key is required. Pass api_key or set FMP_API_KEY env var.")
+
+    records: list[dict] = []
+    for batch in _chunks(symbols_df["symbol"].tolist(), batch_size):
+        symbols = ",".join(batch)
+        url = f"{FMP_PROFILE_URL}/{symbols}"
+        try:
+            response = requests.get(url, params={"apikey": resolved_key}, timeout=30)
+            response.raise_for_status()
+            result = response.json()
+            if not isinstance(result, list):
+                result = []
+        except requests.RequestException:
+            result = []
+
+        for item in result:
+            records.append({
+                "symbol": item.get("symbol"),
+                "market_cap": item.get("mktCap"),
+                "sector": item.get("sector"),
+                "industry": item.get("industry"),
+                "quote_type": item.get("ipoDate"),
+                "meta_source": "fmp",
+            })
+        time.sleep(0.1)
+
+    meta = pd.DataFrame(records).drop_duplicates(subset=["symbol"]) if records else pd.DataFrame(columns=["symbol", "market_cap", "sector", "industry", "quote_type", "meta_source"])
+    merged = symbols_df.merge(meta, on="symbol", how="left")
+    merged["stock_category"] = merged["sector"].fillna("Unknown")
+    return merged
+
+
+def download_stock_list_to_csv(
+    output_csv: str = "latest_us_stock_list.csv",
+    metadata_source: str = "yahoo",
+    fmp_api_key: str | None = None,
+) -> pd.DataFrame:
+    """Download latest stock list + market size + stock category and save to CSV.
+
+    metadata_source: "yahoo" or "fmp".
+    """
+    symbols = fetch_us_stock_symbols()
+    source = metadata_source.lower().strip()
+    if source == "yahoo":
+        enriched = enrich_with_yahoo_metadata(symbols)
+    elif source == "fmp":
+        enriched = enrich_with_fmp_metadata(symbols, api_key=fmp_api_key)
+    else:
+        raise ValueError("Unsupported metadata_source. Use 'yahoo' or 'fmp'.")
+
+    enriched.to_csv(output_csv, index=False)
+    return enriched


### PR DESCRIPTION
### Motivation
- Provide a simple, reproducible one-month stock price-change forecasting model with feature engineering and walk-forward backtest capability. 
- Include utilities to build multi-stock datasets and download an enriched US stock symbol list with market-cap and sector metadata for scaling experiments. 
- Ship a standalone example folder so the forecasting code can be copied into its own repo and run independently. 

### Description
- Added a new forecasting implementation `yahoo_finance_api/forecast_model.py` that provides `StockForecastModel`, `ModelArtifacts`, `predict_latest`, `backtest_predictions`, and `build_multi_stock_dataset` using `GradientBoostingRegressor` and engineered features (MA20/120/200, price-weighted volume, momentum, gold/VIX weekly changes, large-cap flag, and one-hot category). 
- Added `yahoo_finance_api/stock_universe.py` with utilities `fetch_us_stock_symbols`, `enrich_with_yahoo_metadata`, `enrich_with_fmp_metadata`, and `download_stock_list_to_csv` to obtain symbol lists and metadata from Yahoo and Financial Modeling Prep. 
- Updated package exports in `yahoo_finance_api/__init__.py` to expose `ModelArtifacts`, `StockForecastModel`, `build_multi_stock_dataset`, and the stock-universe functions. 
- Added a standalone folder `standalone_stock_forecast/` containing a lightweight `forecast_model.py`, `yahoo_client.py` (minimal Yahoo chart downloader), `train_example.py`, `stock_list_downloader.py`, and `requirements.txt` so the project can be copied and run independently, plus `standalone_stock_forecast/README.md` documenting usage. 
- Extended top-level `README.md` with a Gradient Boosting forecast model example, visualization/backtest snippets, and instructions for downloading the stock list CSV. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134d8f7c50832ba99ec838ad86a0c3)