### PR TITLE
Add stock forecasting model, backtester, and stock-universe downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,74 @@ python setup.py install
 
 Make sure to use TICKER symbol from yahoo finance website
 https://in.finance.yahoo.com/ 
+
+## Forecast model example (Gradient Boosting)
+
+```python
+from yahoo_finance_api import StockForecastModel
+
+model = StockForecastModel(
+    stock_ticker="AAPL",
+    market_cap_usd=2_900_000_000_000,
+    category_label="technology"
+)
+
+artifacts = model.train()
+print("MAE:", artifacts.mae)
+print("R2:", artifacts.r2)
+print("Predicted next 1-month change:", model.predict_latest())
+```
+
+The model uses daily OHLCV, 20/120/200-day moving averages, price-weighted
+volume for 1-week and 1-month windows, weekly gold and VIX changes, and a
+large-cap (>10B) indicator with stock category encoding.
+
+
+You can also visualize historical trend with MA5, MA20, MA120:
+
+```python
+model.load_raw_data()
+ax = model.plot_historical_trend(window_size=250)
+```
+
+
+Backtest (walk-forward, predicted vs actual 1-month return):
+
+```python
+bt = model.backtest_predictions(min_train_size=252, step=1)
+ax = model.plot_backtest(min_train_size=252, step=1)
+```
+
+
+## Download latest stock list to CSV
+
+```python
+from yahoo_finance_api import download_stock_list_to_csv
+
+df = download_stock_list_to_csv("latest_us_stock_list.csv")
+print(df.head())
+```
+
+This CSV includes stock symbol list, exchange, market cap (market size), and stock category (sector).
+
+
+Use different metadata providers:
+
+```python
+# Yahoo (default)
+df = download_stock_list_to_csv("latest_us_stock_list.csv", metadata_source="yahoo")
+
+# Financial Modeling Prep (recommended fallback)
+df = download_stock_list_to_csv("latest_us_stock_list.csv", metadata_source="fmp", fmp_api_key="YOUR_KEY")
+```
+
+
+Model evaluation (MAE/RMSE) and prediction plots:
+
+```python
+metrics = model.evaluate_performance(test_size=0.2)
+print(metrics)  # {"mae": ..., "rmse": ..., "test_rows": ...}
+
+ax1 = model.plot_performance(test_size=0.2)
+ax2 = model.plot_prediction_scatter(test_size=0.2)
+```

--- a/README.md
+++ b/README.md
@@ -106,3 +106,12 @@ print(metrics)  # {"mae": ..., "rmse": ..., "test_rows": ...}
 ax1 = model.plot_performance(test_size=0.2)
 ax2 = model.plot_prediction_scatter(test_size=0.2)
 ```
+
+
+Feature importance check:
+
+```python
+fi = model.get_feature_importance(top_n=20)
+print(fi.head(10))
+ax = model.plot_feature_importance(top_n=20)
+```

--- a/standalone_stock_forecast/README.md
+++ b/standalone_stock_forecast/README.md
@@ -1,0 +1,81 @@
+# Standalone Stock Forecast Model
+
+This folder is structured so you can copy it into a **new GitHub repository** and run it independently.
+
+## What it does
+- Downloads daily OHLCV stock data from Yahoo Finance.
+- Builds engineered features:
+  - 20/120/200-day moving averages
+  - price-weighted volume + 1-week / 1-month rolling averages
+  - 1-week / 1-month momentum
+  - weekly gold change
+  - weekly VIX change
+  - stock category (one-hot encoded)
+  - market cap bucket (>10B)
+- Trains a **GradientBoostingRegressor** to predict the next 1-month (21 trading days) return.
+- Includes historical trend plotting with MA5, MA20, and MA120 lines.
+
+## Project structure
+- `yahoo_client.py` - lightweight Yahoo chart API downloader
+- `forecast_model.py` - feature engineering + training/inference code
+- `train_example.py` - runnable example
+- `requirements.txt` - Python dependencies
+- `stock_list_downloader.py` - download latest stock list + market cap + category to CSV
+
+## Quick start
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python train_example.py
+```
+
+## Move to a new repo
+1. Create a new empty GitHub repo.
+2. Copy all files from `standalone_stock_forecast/` into that repo root.
+3. Commit and push.
+
+
+## Plot historical trend
+```python
+from forecast_model import StockForecastModel
+
+model = StockForecastModel("AAPL", 2_900_000_000_000, "technology")
+model.load_raw_data()
+ax = model.plot_historical_trend(window_size=250)
+```
+
+
+## Backtest historical forecasts
+```python
+bt = model.backtest_predictions(min_train_size=252, step=1)
+ax = model.plot_backtest(min_train_size=252, step=1)
+```
+
+
+## Download latest stock list CSV
+```bash
+python stock_list_downloader.py
+```
+
+
+Use different metadata providers:
+
+```python
+# Yahoo (default)
+df = download_stock_list_to_csv("latest_us_stock_list.csv", metadata_source="yahoo")
+
+# Financial Modeling Prep (recommended fallback)
+df = download_stock_list_to_csv("latest_us_stock_list.csv", metadata_source="fmp", fmp_api_key="YOUR_KEY")
+```
+
+
+Model evaluation (MAE/RMSE) and prediction plots:
+
+```python
+metrics = model.evaluate_performance(test_size=0.2)
+print(metrics)  # {"mae": ..., "rmse": ..., "test_rows": ...}
+
+ax1 = model.plot_performance(test_size=0.2)
+ax2 = model.plot_prediction_scatter(test_size=0.2)
+```

--- a/standalone_stock_forecast/README.md
+++ b/standalone_stock_forecast/README.md
@@ -79,3 +79,12 @@ print(metrics)  # {"mae": ..., "rmse": ..., "test_rows": ...}
 ax1 = model.plot_performance(test_size=0.2)
 ax2 = model.plot_prediction_scatter(test_size=0.2)
 ```
+
+
+Feature importance check:
+
+```python
+fi = model.get_feature_importance(top_n=20)
+print(fi.head(10))
+ax = model.plot_feature_importance(top_n=20)
+```

--- a/standalone_stock_forecast/forecast_model.py
+++ b/standalone_stock_forecast/forecast_model.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from typing import Optional
+
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import train_test_split
+
+from yahoo_client import YahooFinanceClient
+
+
+@dataclass
+class ModelArtifacts:
+    model: GradientBoostingRegressor
+    feature_columns: list[str]
+    mae: float
+    r2: float
+
+
+class StockForecastModel:
+    def __init__(
+        self,
+        stock_ticker: str,
+        market_cap_usd: float,
+        category_label: str,
+        history_range: str = "5y",
+    ) -> None:
+        self.stock_ticker = stock_ticker
+        self.market_cap_usd = market_cap_usd
+        self.category_label = category_label
+        self.history_range = history_range
+        self.data: Optional[pd.DataFrame] = None
+        self.artifacts: Optional[ModelArtifacts] = None
+        self._eval_cache: Optional[pd.DataFrame] = None
+
+    def load_raw_data(self) -> pd.DataFrame:
+        stock = YahooFinanceClient(self.stock_ticker, self.history_range, "1d").fetch()
+        gold = YahooFinanceClient("GC=F", self.history_range, "1d").fetch()
+        vix = YahooFinanceClient("^VIX", self.history_range, "1d").fetch()
+
+        df = stock[["Open", "High", "Low", "Close", "Volume"]].copy()
+        df["gold_close"] = gold["Close"].reindex(df.index).ffill()
+        df["vix_close"] = vix["Close"].reindex(df.index).ffill()
+        self.data = df.dropna()
+        return self.data
+
+    def build_features(self) -> pd.DataFrame:
+        if self.data is None:
+            self.load_raw_data()
+
+        df = self.data.copy()
+        df["ma_20"] = df["Close"].rolling(20).mean()
+        df["ma_120"] = df["Close"].rolling(120).mean()
+        df["ma_200"] = df["Close"].rolling(200).mean()
+
+        df["price_weighted_volume"] = df["Close"] * df["Volume"]
+        df["pwv_1w"] = df["price_weighted_volume"].rolling(5).mean()
+        df["pwv_1m"] = df["price_weighted_volume"].rolling(21).mean()
+
+        df["change_1w"] = df["Close"].pct_change(5)
+        df["change_1m"] = df["Close"].pct_change(21)
+        df["gold_change_1w"] = df["gold_close"].pct_change(5)
+        df["vix_change_1w"] = df["vix_close"].pct_change(5)
+
+        df["stock_category"] = self.category_label
+        df["is_large_cap_10b"] = float(self.market_cap_usd > 10_000_000_000)
+
+        df["target_1m_price_change"] = df["Close"].shift(-21) / df["Close"] - 1
+        df = pd.get_dummies(df, columns=["stock_category"], drop_first=False)
+
+        feature_cols = [
+            "Open", "High", "Low", "Close", "Volume", "ma_20", "ma_120", "ma_200",
+            "pwv_1w", "pwv_1m", "change_1w", "change_1m", "gold_change_1w", "vix_change_1w",
+            "is_large_cap_10b",
+        ] + [c for c in df.columns if c.startswith("stock_category_")]
+
+        self.data = df[feature_cols + ["target_1m_price_change"]].dropna()
+        return self.data
+
+
+    def plot_historical_trend(self, window_size: int = 180):
+        """Plot historical close trend with MA5/MA20/MA120."""
+        if self.data is None:
+            self.load_raw_data()
+
+        base = self.data[["Close"]].copy()
+        base["MA5"] = base["Close"].rolling(5).mean()
+        base["MA20"] = base["Close"].rolling(20).mean()
+        base["MA120"] = base["Close"].rolling(120).mean()
+
+        plot_df = base.tail(window_size).dropna()
+        ax = plot_df[["Close", "MA5", "MA20", "MA120"]].plot(
+            figsize=(12, 6),
+            title=f"{self.stock_ticker} Historical Trend (last {window_size} periods)"
+        )
+        ax.set_xlabel("Date")
+        ax.set_ylabel("Price")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def train(self, random_state: int = 42) -> ModelArtifacts:
+        if self.data is None or "target_1m_price_change" not in self.data.columns:
+            self.build_features()
+
+        X = self.data.drop(columns=["target_1m_price_change"])
+        y = self.data["target_1m_price_change"]
+        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
+
+        model = GradientBoostingRegressor(random_state=random_state)
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+
+        self.artifacts = ModelArtifacts(
+            model=model,
+            feature_columns=list(X.columns),
+            mae=float(mean_absolute_error(y_test, preds)),
+            r2=float(r2_score(y_test, preds)),
+        )
+        return self.artifacts
+
+
+    def evaluate_performance(self, test_size: float = 0.2, random_state: int = 42) -> dict:
+        """Evaluate model with MAE and RMSE and cache prediction frame."""
+        if self.data is None or "target_1m_price_change" not in self.data.columns:
+            self.build_features()
+
+        df = self.data.copy()
+        X = df.drop(columns=["target_1m_price_change"])
+        y = df["target_1m_price_change"]
+
+        split_idx = int(len(df) * (1 - test_size))
+        X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]
+        y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]
+
+        model = GradientBoostingRegressor(random_state=random_state)
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+
+        eval_df = pd.DataFrame({
+            "actual": y_test.values,
+            "predicted": preds,
+        }, index=y_test.index)
+        eval_df["error"] = eval_df["predicted"] - eval_df["actual"]
+        self._eval_cache = eval_df
+
+        mae = float(mean_absolute_error(y_test, preds))
+        rmse = float(mean_squared_error(y_test, preds) ** 0.5)
+        return {"mae": mae, "rmse": rmse, "test_rows": len(y_test)}
+
+    def plot_performance(self, test_size: float = 0.2, random_state: int = 42):
+        """Plot actual vs predicted returns on the test window."""
+        if self._eval_cache is None:
+            self.evaluate_performance(test_size=test_size, random_state=random_state)
+
+        ax = self._eval_cache[["actual", "predicted"]].plot(
+            figsize=(12, 6),
+            title=f"{self.stock_ticker} Test Set: Actual vs Predicted 1-Month Return"
+        )
+        ax.set_xlabel("Date")
+        ax.set_ylabel("1-Month Return")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def plot_prediction_scatter(self, test_size: float = 0.2, random_state: int = 42):
+        """Scatter plot of actual vs predicted with y=x reference line."""
+        if self._eval_cache is None:
+            self.evaluate_performance(test_size=test_size, random_state=random_state)
+
+        ax = self._eval_cache.plot.scatter(x="actual", y="predicted", figsize=(7, 7), alpha=0.6)
+        lim_low = min(self._eval_cache["actual"].min(), self._eval_cache["predicted"].min())
+        lim_high = max(self._eval_cache["actual"].max(), self._eval_cache["predicted"].max())
+        ax.plot([lim_low, lim_high], [lim_low, lim_high], "r--", linewidth=1)
+        ax.set_title(f"{self.stock_ticker} Actual vs Predicted Scatter")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def backtest_predictions(self, min_train_size: int = 252, step: int = 1) -> pd.DataFrame:
+        """Walk-forward backtest: predict next 1-month return for each day.
+
+        Uses only historical data available up to each forecast date, then compares
+        with the realized 1-month forward return.
+        """
+        if self.data is None or "target_1m_price_change" not in self.data.columns:
+            self.build_features()
+
+        df = self.data.copy()
+        X_all = df.drop(columns=["target_1m_price_change"])
+        y_all = df["target_1m_price_change"]
+
+        records = []
+        model = GradientBoostingRegressor(random_state=42)
+
+        for i in range(min_train_size, len(df), step):
+            X_train = X_all.iloc[:i]
+            y_train = y_all.iloc[:i]
+            X_test = X_all.iloc[[i]]
+
+            model.fit(X_train, y_train)
+            pred = float(model.predict(X_test)[0])
+            actual = float(y_all.iloc[i])
+
+            records.append({
+                "date": df.index[i],
+                "predicted_1m_change": pred,
+                "actual_1m_change": actual,
+            })
+
+        backtest_df = pd.DataFrame(records).set_index("date")
+        backtest_df["prediction_error"] = backtest_df["predicted_1m_change"] - backtest_df["actual_1m_change"]
+        return backtest_df
+
+    def plot_backtest(self, min_train_size: int = 252, step: int = 1):
+        """Plot historical backtest with predicted vs actual 1-month return."""
+        backtest_df = self.backtest_predictions(min_train_size=min_train_size, step=step)
+        ax = backtest_df[["actual_1m_change", "predicted_1m_change"]].plot(
+            figsize=(12, 6),
+            title=f"{self.stock_ticker} Backtest: Actual vs Predicted 1-Month Change"
+        )
+        ax.set_xlabel("Date")
+        ax.set_ylabel("1-Month Return")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def predict_latest(self) -> float:
+        if self.artifacts is None:
+            raise RuntimeError("Train model first.")
+        latest = self.data[self.artifacts.feature_columns].tail(1)
+        return float(self.artifacts.model.predict(latest)[0])

--- a/standalone_stock_forecast/forecast_model.py
+++ b/standalone_stock_forecast/forecast_model.py
@@ -37,6 +37,7 @@ class StockForecastModel:
         self.data: Optional[pd.DataFrame] = None
         self.artifacts: Optional[ModelArtifacts] = None
         self._eval_cache: Optional[pd.DataFrame] = None
+        self._last_model: Optional[GradientBoostingRegressor] = None
 
     def load_raw_data(self) -> pd.DataFrame:
         stock = YahooFinanceClient(self.stock_ticker, self.history_range, "1d").fetch()
@@ -115,6 +116,7 @@ class StockForecastModel:
         model.fit(X_train, y_train)
         preds = model.predict(X_test)
 
+        self._last_model = model
         self.artifacts = ModelArtifacts(
             model=model,
             feature_columns=list(X.columns),
@@ -177,6 +179,31 @@ class StockForecastModel:
         ax.plot([lim_low, lim_high], [lim_low, lim_high], "r--", linewidth=1)
         ax.set_title(f"{self.stock_ticker} Actual vs Predicted Scatter")
         ax.grid(alpha=0.3)
+        return ax
+
+
+    def get_feature_importance(self, top_n: int | None = None) -> pd.DataFrame:
+        """Return feature importances from the latest trained model."""
+        if self.artifacts is None or self._last_model is None:
+            self.train()
+
+        importance_df = pd.DataFrame({
+            "feature": self.artifacts.feature_columns,
+            "importance": self._last_model.feature_importances_,
+        }).sort_values("importance", ascending=False).reset_index(drop=True)
+
+        if top_n is not None:
+            return importance_df.head(top_n)
+        return importance_df
+
+    def plot_feature_importance(self, top_n: int = 20):
+        """Plot top-N feature importances from the trained model."""
+        fi = self.get_feature_importance(top_n=top_n).iloc[::-1]
+        ax = fi.plot.barh(x="feature", y="importance", figsize=(10, max(4, int(top_n * 0.35))))
+        ax.set_title(f"{self.stock_ticker} Feature Importance (Top {min(top_n, len(fi))})")
+        ax.set_xlabel("Importance")
+        ax.set_ylabel("Feature")
+        ax.grid(axis="x", alpha=0.3)
         return ax
 
     def backtest_predictions(self, min_train_size: int = 252, step: int = 1) -> pd.DataFrame:

--- a/standalone_stock_forecast/requirements.txt
+++ b/standalone_stock_forecast/requirements.txt
@@ -1,0 +1,5 @@
+pandas>=2.0.0
+numpy>=1.24.0
+requests>=2.28.0
+scikit-learn>=1.3.0
+matplotlib>=3.7.0

--- a/standalone_stock_forecast/stock_list_downloader.py
+++ b/standalone_stock_forecast/stock_list_downloader.py
@@ -1,0 +1,14 @@
+import os
+
+from yahoo_finance_api.stock_universe import download_stock_list_to_csv
+
+
+if __name__ == "__main__":
+    source = os.getenv("STOCK_META_SOURCE", "yahoo")
+    fmp_key = os.getenv("FMP_API_KEY")
+    df = download_stock_list_to_csv(
+        output_csv="latest_us_stock_list.csv",
+        metadata_source=source,
+        fmp_api_key=fmp_key,
+    )
+    print(f"Saved {len(df)} rows to latest_us_stock_list.csv using source={source}")

--- a/standalone_stock_forecast/train_example.py
+++ b/standalone_stock_forecast/train_example.py
@@ -1,0 +1,18 @@
+from forecast_model import StockForecastModel
+
+
+if __name__ == "__main__":
+    model = StockForecastModel(
+        stock_ticker="AAPL",
+        market_cap_usd=2_900_000_000_000,
+        category_label="technology",
+        history_range="5y",
+    )
+
+    artifacts = model.train()
+    prediction = model.predict_latest()
+
+    print("Model trained successfully")
+    print("MAE:", artifacts.mae)
+    print("R2:", artifacts.r2)
+    print("Predicted 1-month forward return:", prediction)

--- a/standalone_stock_forecast/yahoo_client.py
+++ b/standalone_stock_forecast/yahoo_client.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import time as _time
+
+import pandas as pd
+import requests
+
+
+class YahooFinanceClient:
+    def __init__(self, ticker: str, result_range: str = "1y", interval: str = "1d") -> None:
+        self.ticker = ticker
+        self.result_range = result_range
+        self.interval = interval
+
+    def fetch(self) -> pd.DataFrame:
+        headers = {"User-Agent": "Mozilla/5.0"}
+        params = {"range": self.result_range, "interval": self.interval}
+        url = f"https://query1.finance.yahoo.com/v8/finance/chart/{self.ticker}"
+
+        response = requests.get(url=url, params=params, headers=headers, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+
+        error = data["chart"]["error"]
+        if error:
+            raise ValueError(error["description"])
+
+        result = data["chart"]["result"][0]
+        timestamps = result["timestamp"]
+        quote = result["indicators"]["quote"][0]
+
+        index = [_time.strftime("%Y-%m-%d", _time.localtime(ts)) for ts in timestamps]
+        df = pd.DataFrame(
+            {
+                "Open": quote["open"],
+                "High": quote["high"],
+                "Low": quote["low"],
+                "Close": quote["close"],
+                "Volume": quote["volume"],
+            },
+            index=pd.to_datetime(index),
+        )
+
+        return df.dropna()

--- a/stock_list.csv
+++ b/stock_list.csv
@@ -1,0 +1,743 @@
+symbol,name,price,marketCap,volume,industry
+NVDA,NVIDIA Corporation Common Stock,215.33,5210986000000.0,168335101,Technology
+GOOGL,Alphabet Inc. Class A Common Stock,382.97,4640064520000.0,20401575,Technology
+GOOG,Alphabet Inc. Class C Capital Stock,379.38,4596568080000.0,13336255,Technology
+AAPL,Apple Inc. Common Stock,308.82,4535749279920.0,43627655,Technology
+MSFT,Microsoft Corporation Common Stock,418.57,3109319914053.0,22341390,Technology
+AMZN,Amazon.com Inc. Common Stock,266.32,2864833384996.0,27470312,Consumer Discretionary
+AVGO,Broadcom Inc. Common Stock,414.14,1960815481722.0,14062227,Technology
+TSLA,Tesla Inc. Common Stock,426.01,1599975926285.0,45942422,Industrials
+META,Meta Platforms Inc. Class A Common Stock,610.26,1549098205499.0,11671771,Technology
+BRK/B,Berkshire Hathaway Inc.,486.38,1073105724627.0,4337981,Uncategorized
+BRK/A,Berkshire Hathaway Inc.,728641.0,1071739102234.0,429,Uncategorized
+LLY,Eli Lilly and Company Common Stock,1065.0,1002954597390.0,3470664,Health Care
+WMT,Walmart Inc. Common Stock,120.27,958840848795.0,30295667,Consumer Discretionary
+MU,Micron Technology Inc. Common Stock,751.0,846928272301.0,35775472,Technology
+JPM,JP Morgan Chase & Co. Common Stock,306.38,820948708247.0,5973590,Finance
+AMD,Advanced Micro Devices Inc. Common Stock,467.51,762322104739.0,34658788,Technology
+XOM,Exxon Mobil Corporation Common Stock,154.92,642135214337.0,12924608,Energy
+V,Visa Inc.,328.88,623052621698.0,7462051,Consumer Discretionary
+INTC,Intel Corporation Common Stock,119.84,602315840000.0,82206726,Technology
+JNJ,Johnson & Johnson Common Stock,234.34,564107224984.0,5462267,Health Care
+ORCL,Oracle Corporation Common Stock,192.08,552430915680.0,10844582,Technology
+CSCO,Cisco Systems Inc. Common Stock (DE),120.41,474588148013.0,22217474,Telecommunications
+COST,Costco Wholesale Corporation Common Stock,1028.24,456181287730.0,2048431,Consumer Discretionary
+MA,Mastercard Incorporated Common Stock,498.54,440501895072.0,1959272,Consumer Discretionary
+CAT,Caterpillar Inc. Common Stock,879.89,405309912807.0,1987541,Industrials
+LRCX,Lam Research Corporation Common Stock,305.35,381861854850.0,7854642,Technology
+CVX,Chevron Corporation Common Stock,191.43,381251553837.0,7209626,Energy
+ABBV,AbbVie Inc. Common Stock,215.7,381097211490.0,5405779,Health Care
+NFLX,Netflix Inc. Common Stock,88.6,373076749581.0,23790976,Consumer Discretionary
+BAC,Bank of America Corporation Common Stock,51.8,367603395722.0,26666936,Finance
+UNH,UnitedHealth Group Incorporated Common Stock (DE),388.47,352786856622.0,5598561,Health Care
+KO,Coca-Cola Company (The) Common Stock,81.48,350702376418.0,8239521,Consumer Staples
+AMAT,Applied Materials Inc. Common Stock,432.16,342966440123.0,4889100,Technology
+PG,Procter & Gamble Company (The) Common Stock,144.44,336342836382.0,4616720,Consumer Discretionary
+PLTR,Palantir Technologies Inc. Class A Common Stock,136.88,328144063412.0,27486320,Technology
+MS,Morgan Stanley Common Stock,201.03,317081566762.0,3734177,Finance
+GE,GE Aerospace Common Stock,302.84,315964248247.0,3502121,Technology
+HD,Home Depot Inc. (The) Common Stock,313.07,311826378890.0,2963785,Consumer Discretionary
+MRK,Merck & Company Inc. Common Stock (new),122.41,302331206640.0,14749066,Health Care
+PM,Philip Morris International Inc Common Stock,188.99,294552036306.0,2385207,Health Care
+GS,Goldman Sachs Group Inc. (The) Common Stock,996.73,294042746733.0,1923550,Finance
+TXN,Texas Instruments Incorporated Common Stock,309.21,281409791905.0,7129022,Technology
+GEV,GE Vernova Inc. Common Stock,1038.74,279130207606.0,1472308,Uncategorized
+QCOM,QUALCOMM Incorporated Common Stock,238.16,251020640000.0,30332369,Technology
+KLAC,KLA Corporation Common Stock,1888.38,246674398106.0,723058,Technology
+LIN,Linde plc Ordinary Shares,517.58,239432269396.0,1453999,Basic Materials
+IBM,International Business Machines Corporation Common Stock,253.84,238580479475.0,19022593,Technology
+RTX,RTX Corporation Common Stock,177.01,238376433590.0,4315425,Industrials
+WFC,Wells Fargo & Company Common Stock,76.4,233798477342.0,8728737,Finance
+CCZ,Comcast Holdings ZONES,63.9,228367191933.0,6,Telecommunications
+SNDK,Sandisk Corporation Common Stock,1478.69,218978844257.0,9601761,Technology
+C,Citigroup Inc. Common Stock,125.09,213350621301.0,6330807,Finance
+AXP,American Express Company Common Stock,311.78,212735738399.0,2209179,Finance
+PANW,Palo Alto Networks Inc. Common Stock,260.58,212633280000.0,6626112,Technology
+TMUS,T-Mobile US Inc. Common Stock,191.47,207209737164.0,3973828,Telecommunications
+PEP,PepsiCo Inc. Common Stock,150.57,205794305190.0,7774448,Consumer Staples
+VZ,Verizon Communications Inc. Common Stock,48.35,201888273299.0,14717757,Telecommunications
+MCD,McDonald's Corporation Common Stock,282.27,200554488820.0,3056218,Consumer Discretionary
+ANET,Arista Networks Inc. Common Stock,154.03,193954975400.0,10554723,Telecommunications
+ADI,Analog Devices Inc. Common Stock,397.07,193407650973.0,6107847,Technology
+DELL,Dell Technologies Inc. Class C Common Stock ,295.19,191746062640.0,15258553,Technology
+NEE,NextEra Energy Inc. Common Stock,88.55,184656985929.0,10755126,Technology
+AMGN,Amgen Inc. Common Stock,339.3,183123017368.0,1566152,Health Care
+DIS,Walt Disney Company (The) Common Stock,103.0,178860676672.0,5693031,Consumer Discretionary
+T,AT&T Inc.,25.26,175515038972.0,25271113,Telecommunications
+TJX,TJX Companies Inc. (The) Common Stock,158.27,175017223405.0,4844754,Consumer Discretionary
+BA,Boeing Company (The) Common Stock,219.02,172653976536.0,4632391,Industrials
+MRVL,Marvell Technology Inc. Common Stock,196.33,171897354455.0,19768801,Technology
+CRWD,CrowdStrike Holdings Inc. Class A Common Stock,663.46,168874800223.0,2778924,Technology
+GLW,Corning Incorporated Common Stock,194.05,167006769941.0,9608856,Industrials
+WDC,Western Digital Corporation Common Stock,484.28,166922662401.0,4481914,Technology
+GILD,Gilead Sciences Inc. Common Stock,134.36,166817328271.0,5973428,Health Care
+TMO,Thermo Fisher Scientific Inc Common Stock,448.28,166590470330.0,1686001,Industrials
+BLK,BlackRock Inc. Common Stock,1073.0,166566070197.0,450921,Finance
+CRM,Salesforce Inc. Common Stock,180.07,166204610000.0,10176549,Technology
+APH,Amphenol Corporation Common Stock,132.06,162464760807.0,17731007,Technology
+APP,Applovin Corporation Class A Common Stock,481.68,161815579200.0,3822258,Technology
+UNP,Union Pacific Corporation Common Stock,265.88,157856469072.0,2597295,Industrials
+SCHW,Charles Schwab Corporation (The) Common Stock,90.15,156783065956.0,7065586,Finance
+ISRG,Intuitive Surgical Inc. Common Stock,438.1,155158741080.0,2009075,Health Care
+WELL,Welltower Inc. Common Stock,216.17,152597526657.0,2291875,Real Estate
+ABT,Abbott Laboratories Common Stock,87.41,152251824419.0,9516355,Health Care
+TBB,AT&T Inc. 5.350% Global Notes due 2066,20.98,150015087370.0,86032,Telecommunications
+SCCO,Southern Copper Corporation Common Stock,179.67,148419105916.0,1041187,Basic Materials
+PFE,Pfizer Inc. Common Stock,25.9,147615603977.0,22297760,Health Care
+COP,ConocoPhillips Common Stock,120.46,146755696083.0,4947379,Energy
+UBER,Uber Technologies Inc. Common Stock,71.82,146196721114.0,19640579,Consumer Discretionary
+HON,Honeywell International Inc. Common Stock,227.92,144422218882.0,5071118,Industrials
+DE,Deere & Company Common Stock,529.15,142927268270.0,1763853,Industrials
+IBKR,Interactive Brokers Group Inc. Class A Common Stock,81.35,137998376912.0,8382201,Finance
+PLD,Prologis Inc. Common Stock,145.9,136028114200.0,2327678,Real Estate
+VRT,Vertiv Holdings LLC Class A Common Stock,327.46,125780272887.0,4792072,Technology
+BKNG,Booking Holdings Inc. Common Stock,161.06,124801920902.0,7379704,Consumer Discretionary
+SPGI,S&P Global Inc. Common Stock,417.6,123609600000.0,2187587,Finance
+MO,Altria Group Inc.,73.9,123404962267.0,4505313,Health Care
+LMT,Lockheed Martin Corporation Common Stock,533.24,122945738330.0,1050538,Industrials
+DHR,Danaher Corporation Common Stock,172.0,121736547844.0,2995034,Industrials
+BMY,Bristol-Myers Squibb Company Common Stock,59.46,121421556347.0,6489214,Health Care
+SYK,Stryker Corporation Common Stock,316.48,121326013958.0,1893069,Health Care
+LOW,Lowe's Companies Inc. Common Stock,215.03,120430439138.0,2801317,Consumer Discretionary
+CVS,CVS Health Corporation Common Stock,93.26,118992980651.0,4838475,Consumer Staples
+SBUX,Starbucks Corporation Common Stock,103.11,117514467000.0,9095677,Consumer Discretionary
+COF,Capital One Financial Corporation Common Stock,187.79,116860361720.0,3291902,Finance
+PGR,Progressive Corporation (The) Common Stock,199.51,116580967933.0,5461068,Finance
+NEM,Newmont Corporation,107.64,114911379517.0,5038860,Basic Materials
+VRTX,Vertex Pharmaceuticals Incorporated Common Stock,434.52,110283529795.0,1746303,Health Care
+PH,Parker-Hannifin Corporation Common Stock,866.96,109311855807.0,702930,Industrials
+PWR,Quanta Services Inc. Common Stock,723.44,108559514193.0,774763,Industrials
+SO,Southern Company (The) Common Stock,94.55,106682639454.0,3396162,Utilities
+EQIX,Equinix Inc. Common Stock REIT,1079.79,106493476748.0,427151,Real Estate
+CEG,Constellation Energy Corporation Common Stock ,294.07,106215161826.0,2877684,Utilities
+CME,CME Group Inc. Class A Common Stock,291.23,105529912627.0,1437449,Finance
+NOW,ServiceNow Inc. Common Stock,102.13,105296030000.0,23544968,Technology
+CDNS,Cadence Design Systems Inc. Common Stock,373.59,103042099440.0,2206181,Technology
+HWM,Howmet Aerospace Inc. Common Stock,256.55,102647574764.0,1694813,Industrials
+MDT,Medtronic plc. Ordinary Shares,78.6,100913358170.0,7051354,Health Care
+SNPS,Synopsys Inc. Common Stock,524.74,100520258048.0,1873067,Technology
+ADBE,Adobe Inc. Common Stock,244.76,98931992000.0,3779271,Technology
+FTNT,Fortinet Inc. Common Stock,133.93,98123599007.0,5819073,Technology
+DUK,Duke Energy Corporation (Holding Company) Common Stock,125.67,97971856590.0,2446330,Utilities
+MAR,Marriott International Class A Common Stock,369.15,97340655180.0,820066,Consumer Discretionary
+WMB,Williams Companies Inc. (The) Common Stock,78.47,95968673855.0,6201683,Utilities
+BNY,The Bank of New York Mellon Corporation Common Stock,139.15,95509644112.0,3574005,Finance
+FDX,FedEx Corporation Common Stock,394.2,94058783215.0,1508084,Consumer Discretionary
+GD,General Dynamics Corporation Common Stock,342.89,92727806820.0,689314,Industrials
+MCK,McKesson Corporation Common Stock,766.08,92085919390.0,2323944,Health Care
+ADP,Automatic Data Processing Inc. Common Stock,225.31,90719801653.0,2282603,Industrials
+CMCSA,Comcast Corporation Class A Common Stock,25.205,90078170151.0,26573582,Telecommunications
+FCX,Freeport-McMoRan Inc. Common Stock,61.99,89114336031.0,7855960,Basic Materials
+CMI,Cummins Inc. Common Stock,639.55,88250907800.0,1106868,Industrials
+BX,Blackstone Inc. Common Stock,118.51,88038685928.0,3968650,Finance
+PNC,PNC Financial Services Group Inc. (The) Common Stock,219.23,88035014273.0,1204526,Finance
+INTU,Intuit Inc. Common Stock,319.94,87515427780.0,12469556,Technology
+WM,Waste Management Inc. Common Stock,217.9,87503356361.0,1908897,Utilities
+HCA,HCA Healthcare Inc. Common Stock,394.07,87420409986.0,1109789,Health Care
+ICE,Intercontinental Exchange Inc. Common Stock,152.97,86506446360.0,2827786,Finance
+BE,Bloom Energy Corporation Class A Common Stock,302.49,86041425631.0,9487806,Energy
+BSX,Boston Scientific Corporation Common Stock,57.78,85881602243.0,11738128,Health Care
+UPS,United Parcel Service Inc. Common Stock,101.02,85867634305.0,4539723,Industrials
+EPD,Enterprise Products Partners L.P. Common Stock,39.63,85740229080.0,3553700,Utilities
+ELV,Elevance Health Inc. Common Stock,394.69,85711819762.0,1090599,Health Care
+AMT,American Tower Corporation (REIT) Common Stock,183.85,85654440736.0,2069903,Real Estate
+USB,U.S. Bancorp Common Stock,54.83,85112595018.0,5106945,Finance
+MNST,Monster Beverage Corporation,86.79,84881323867.0,3238953,Consumer Staples
+CSX,CSX Corporation Common Stock,45.52,84582480725.0,10761157,Industrials
+KKR,KKR & Co. Inc. Common Stock,94.04,84435971372.0,2824886,Finance
+CIEN,Ciena Corporation Common Stock,583.74,82539917777.0,1622505,Utilities
+ABNB,Airbnb Inc. Class A Common Stock,132.35,79767996559.0,3097348,Consumer Discretionary
+MMM,3M Company Common Stock,152.44,79507713267.0,3209079,Health Care
+MDLZ,Mondelez International Inc. Class A Common Stock,61.76,79278209548.0,7049620,Consumer Staples
+DDOG,Datadog Inc. Class A Common Stock,222.32,79137069218.0,4870864,Technology
+MRSH,Marsh Common Stock,164.11,79067295559.0,2464165,Finance
+NOC,Northrop Grumman Corporation Common Stock,555.58,78910958596.0,651954,Industrials
+RKLB,Rocket Lab Corporation Common Stock,135.76,78587048406.0,32870062,Industrials
+MCO,Moody's Corporation Common Stock,449.12,78461264000.0,502890,Finance
+MPWR,Monolithic Power Systems Inc. Common Stock,1589.81,78107365300.0,476644,Technology
+EMR,Emerson Electric Company Common Stock,136.42,76408842000.0,2950718,Technology
+NET,Cloudflare Inc. Class A Common Stock,216.17,76408798614.0,2109440,Technology
+SHW,Sherwin-Williams Company (The) Common Stock,309.08,76230137739.0,1274418,Consumer Discretionary
+ORLY,O'Reilly Automotive Inc. Common Stock,91.74,76026321347.0,4453732,Consumer Discretionary
+CI,The Cigna Group Common Stock,286.24,75719755321.0,1435096,Health Care
+ROST,Ross Stores Inc. Common Stock,234.81,75643606632.0,4588684,Consumer Discretionary
+EOG,EOG Resources Inc. Common Stock,141.22,75217801007.0,2515052,Energy
+KMI,Kinder Morgan Inc. Common Stock,33.79,75176862329.0,6676520,Utilities
+CVNA,Carvana Co. Class A Common Stock,68.28,74891944327.0,9360991,Consumer Discretionary
+MPC,Marathon Petroleum Corporation Common Stock,254.65,74341664103.0,1926237,Energy
+APO,Apollo Global Management Inc. (New) Common Stock,128.51,74088265596.0,2524742,Finance
+COHR,Coherent Corp. Common Stock,377.57,73867538430.0,3979723,Technology
+LITE,Lumentum Holdings Inc. Common Stock,946.9,73668820000.0,3060442,Telecommunications
+VLO,Valero Energy Corporation Common Stock,246.96,73330519843.0,2532820,Energy
+HLT,Hilton Worldwide Holdings Inc. Common Stock ,321.08,73093339282.0,1053735,Consumer Discretionary
+ITW,Illinois Tool Works Inc. Common Stock,252.2,72557940000.0,874185,Industrials
+CL,Colgate-Palmolive Company Common Stock,90.61,72505153379.0,3771890,Consumer Discretionary
+AEP,American Electric Power Company Inc. Common Stock,131.59,71598781161.0,3280580,Utilities
+ECL,Ecolab Inc. Common Stock,253.32,71293748007.0,1254714,Consumer Discretionary
+PSX,Phillips 66 Common Stock,177.69,71242143704.0,1898491,Energy
+GM,General Motors Company Common Stock,78.79,71042200714.0,6440863,Industrials
+NSC,Norfolk Southern Corporation Common Stock,314.53,70641551135.0,1600147,Industrials
+DASH,DoorDash Inc. Class A Common Stock,160.25,69823925201.0,5102814,Technology
+AON,Aon plc Class A Ordinary Shares (Ireland),324.78,69365521496.0,928979,Finance
+CTAS,Cintas Corporation Common Stock,172.93,69195670831.0,1338500,Industrials
+ET,Energy Transfer LP Common Units ,20.07,69064066689.0,6858003,Utilities
+RCL,Royal Caribbean Cruises Ltd. Common Stock,256.1,68684733866.0,3179904,Consumer Discretionary
+TDG,Transdigm Group Incorporated Common Stock,1213.51,67875962306.0,448608,Industrials
+WBD,Warner Bros. Discovery Inc. Series A Common Stock ,27.03,67767905055.0,19346827,Consumer Discretionary
+DLR,Digital Realty Trust Inc. Common Stock,192.03,67480507622.0,1692502,Real Estate
+MSI,Motorola Solutions Inc. Common Stock,404.08,67075494775.0,957105,Technology
+REGN,Regeneron Pharmaceuticals Inc. Common Stock,638.88,66979560764.0,994942,Health Care
+HOOD,Robinhood Markets Inc. Class A Common Stock,73.64,66313192397.0,20716133,Finance
+SPG,Simon Property Group Inc. Common Stock,204.41,66288100912.0,1152017,Real Estate
+NKE,Nike Inc. Common Stock,44.67,66151223764.0,14885712,Consumer Discretionary
+BKR,Baker Hughes Company Class A Common Stock,66.06,65536058124.0,8382620,Consumer Discretionary
+TRV,The Travelers Companies Inc. Common Stock,306.46,65167092617.0,1386716,Finance
+APD,Air Products and Chemicals Inc. Common Stock,289.47,64459378176.0,1038018,Basic Materials
+FIX,Comfort Systems USA Inc. Common Stock,1828.25,64358831678.0,251971,Industrials
+RSG,Republic Services Inc. Common Stock,208.93,64280257697.0,1611978,Utilities
+SRE,DBA Sempra Common Stock,92.8,60664046813.0,2201907,Utilities
+TFC,Truist Financial Corporation Common Stock,48.38,60275639325.0,5461289,Finance
+AFL,AFLAC Incorporated Common Stock,117.86,59988960785.0,2296174,Finance
+SNOW,Snowflake Inc. Common Stock,172.2,59684740933.0,5951086,Technology
+D,Dominion Energy Inc. Common Stock,67.67,59512747121.0,6459872,Utilities
+F,Ford Motor Company Common Stock,14.93,59491460966.0,109610292,Industrials
+KEYS,Keysight Technologies Inc. Common Stock,346.56,59435904667.0,1626796,Industrials
+TRGP,Targa Resources Inc. Common Stock,276.75,59402700155.0,808815,Utilities
+OKE,ONEOK Inc. Common Stock,94.03,59241989074.0,3099548,Utilities
+GWW,W.W. Grainger Inc. Common Stock,1247.79,58912057757.0,280050,Industrials
+URI,United Rentals Inc. Common Stock,938.62,58801311331.0,339322,Consumer Discretionary
+OXY,Occidental Petroleum Corporation Common Stock,58.81,58494466766.0,7904164,Energy
+SOMN,Southern Company (The) 2025 Series A Corporate Units,51.68,58311568556.0,65208,Basic Materials
+LHX,L3Harris Technologies Inc. Common Stock,311.98,58120298813.0,944803,Industrials
+O,Realty Income Corporation Common Stock,62.02,57833186711.0,4332474,Real Estate
+CRWV,CoreWeave Inc. Class A Common Stock,105.49,57552215800.0,19870355,Technology
+PCAR,PACCAR Inc. Common Stock,109.35,57549399141.0,2403844,Consumer Discretionary
+MPLX,MPLX LP Common Units Representing Limited Partner Interests,56.47,57302013112.0,1789221,Energy
+TGT,Target Corporation Common Stock,125.6,57044536623.0,4943006,Consumer Discretionary
+FANG,Diamondback Energy Inc. Common Stock,200.71,56462391841.0,1523050,Energy
+AZO,AutoZone Inc. Common Stock,3406.5,56128287330.0,511967,Consumer Discretionary
+TER,Teradyne Inc. Common Stock,358.44,56110972547.0,2708488,Industrials
+MSTR,Strategy Inc Common Stock Class A,159.89,56033110254.0,12716683,Technology
+ALL,Allstate Corporation (The) Common Stock,216.6,55757373438.0,1247422,Finance
+CBRS,Cerebras Systems Inc. Class A Common Stock,256.78,55266384758.0,11763492,Technology
+MET,MetLife Inc. Common Stock,84.06,54087295643.0,3779151,Finance
+PSA,Public Storage Common Stock,305.25,53585339577.0,675914,Real Estate
+COR,Cencora Inc. Common Stock,274.91,53486781005.0,2145834,Health Care
+SE,Sea Limited American Depositary Shares each representing one Class A Ordinary Share,87.27,53451524235.0,2712813,Consumer Discretionary
+CTVA,Corteva Inc. Common Stock ,79.56,53211319200.0,2135407,Consumer Staples
+BRKRP,Bruker Corporation 6.375% Mandatory Convertible Preferred Stock Series A,342.49,53081026364.0,158,Industrials
+NUE,Nucor Corporation Common Stock,232.0,52835900400.0,1135848,Industrials
+CARR,Carrier Global Corporation Common Stock ,63.14,52775182709.0,4926840,Industrials
+VST,Vistra Corp. Common Stock,156.27,52691504274.0,8048942,Utilities
+ALAB,Astera Labs Inc. Common Stock,306.88,52601668320.0,6515533,Technology
+AJG,Arthur J. Gallagher & Co. Common Stock,204.75,52600275000.0,1240698,Finance
+EBAY,eBay Inc. Common Stock,115.75,51510044201.0,4202666,Consumer Discretionary
+NDAQ,Nasdaq Inc. Common Stock,91.01,51469868026.0,2549686,Finance
+ETR,Entergy Corporation Common Stock,112.4,51466481603.0,2768354,Utilities
+AME,AMETEK Inc.,224.52,51460658009.0,891694,Industrials
+ADSK,Autodesk Inc. Common Stock,240.99,50883894038.0,2455226,Technology
+HBANL,Huntington Bancshares Incorporated Depositary Shares Each Representing a 1/40th Interest in a Share of 6.875% Series J Non-Cumulative Perpetual Preferred Stock,25.1,50880977734.0,13897,Finance
+XEL,Xcel Energy Inc. Common Stock,81.08,50615775925.0,3738060,Utilities
+MCHP,Microchip Technology Incorporated Common Stock,93.43,50558285841.0,8837362,Technology
+LNG,Cheniere Energy Inc. Common Stock,240.85,50470567408.0,1978367,Utilities
+FAST,Fastenal Company Common Stock,43.94,50444660580.0,5583179,Consumer Discretionary
+EA,Electronic Arts Inc. Common Stock,200.97,50393525739.0,2334300,Consumer Discretionary
+ROK,Rockwell Automation Inc. Common Stock,452.29,50328096202.0,858103,Industrials
+DAL,Delta Air Lines Inc. Common Stock,76.14,50023549048.0,6437004,Consumer Discretionary
+HPE,Hewlett Packard Enterprise Company Common Stock,37.58,49863176665.0,30706286,Technology
+EW,Edwards Lifesciences Corporation Common Stock,85.78,49392124000.0,4941674,Health Care
+COIN,Coinbase Global Inc. Class A Common Stock,184.99,48728421979.0,7894510,Finance
+MDLN,Medline Inc. Class A Common Stock,37.01,48619598950.0,43069862,Health Care
+GFS,GlobalFoundries Inc. Ordinary Shares,85.64,47651573804.0,11779280,Technology
+EXC,Exelon Corporation Common Stock,46.23,47302912405.0,9228187,Utilities
+CAH,Cardinal Health Inc. Common Stock,200.68,47000430981.0,1537245,Health Care
+ON,ON Semiconductor Corporation Common Stock,116.2,45539150794.0,8492581,Technology
+FITB,Fifth Third Bancorp Common Stock,49.48,44844295395.0,3609061,Finance
+HBANM,Huntington Bancshares Incorporated Depositary Shares each representing a 1/1000th interest in a share of Huntington Series I Preferred Stock,22.07,44738772055.0,5393,Finance
+PCG,Pacific Gas & Electric Co. Common Stock,16.49,44192677564.0,14143441,Utilities
+IDXX,IDEXX Laboratories Inc. Common Stock,559.37,44124782032.0,465966,Health Care
+ODFL,Old Dominion Freight Line Inc. Common Stock,210.47,43771084523.0,1269908,Industrials
+WAB,Westinghouse Air Brake Technologies Corporation Common Stock,256.41,43506968288.0,783307,Industrials
+MCHPP,Microchip Technology Incorporated Depositary Shares Each Representing a 1/20th Interest in a Share of 7.50% Series A Mandatory Convertible Preferred Stock,79.59,43068971102.0,10940,Technology
+VTR,Ventas Inc. Common Stock,88.18,42870446174.0,2827084,Real Estate
+MSCI,MSCI Inc. Common Stock,588.55,42846440000.0,412307,Consumer Discretionary
+YUM,Yum! Brands Inc.,155.15,42762629490.0,1640556,Consumer Discretionary
+STT,State Street Corporation Common Stock,153.95,42608284730.0,1542265,Finance
+CMG,Chipotle Mexican Grill Inc. Common Stock,32.89,42189121260.0,18624197,Consumer Discretionary
+TTWO,Take-Two Interactive Software Inc. Common Stock,227.55,42136675013.0,7045317,Consumer Discretionary
+HEI,Heico Corporation Common Stock,301.04,42000618835.0,480777,Industrials
+HBANZ,Huntington Bancshares Incorporated Depositary Shares Each Representing a 1/1000th Interest in a Share of 5.50% Series L Non-Cumulative Perpetual Preferred Stock,20.41,41373735281.0,18173,Finance
+KR,Kroger Company (The) Common Stock,67.25,41199633676.0,5117305,Consumer Staples
+ASTS,AST SpaceMobile Inc. Class A Common Stock,105.86,41086867192.0,30564763,Consumer Discretionary
+ARES,Ares Management Corporation Class A Common Stock,124.41,41036343151.0,1751233,Finance
+AIG,American International Group Inc. New Common Stock,77.05,40852389328.0,2533768,Finance
+DHI,D.R. Horton Inc. Common Stock,143.73,40758897776.0,1811285,Consumer Discretionary
+BDX,Becton Dickinson and Company Common Stock,147.63,40678033238.0,1291274,Health Care
+AMP,Ameriprise Financial Inc. Common Stock,452.31,40661350064.0,629725,Finance
+XYZ,Block Inc. Class A Common Stock,68.08,40519922480.0,5627541,Technology
+CRDO,Credo Technology Group Holding Ltd Ordinary Shares,218.41,40285711395.0,8510379,Technology
+ED,Consolidated Edison Inc. Common Stock,108.54,40000214181.0,2238113,Utilities
+CCI,Crown Castle Inc. Common Stock,91.46,39917898365.0,3045252,Real Estate
+ALNY,Alnylam Pharmaceuticals Inc. Common Stock,297.45,39713314839.0,681280,Health Care
+PEG,Public Service Enterprise Group Incorporated Common Stock,79.51,39621534673.0,2009180,Utilities
+KDP,Keurig Dr Pepper Inc. Common Stock,29.12,39619491796.0,5933174,Consumer Staples
+HSY,The Hershey Company Common Stock,194.78,39509831998.0,1621008,Consumer Staples
+RKT,Rocket Companies Inc. Class A Common Stock,13.79,39017835866.0,17006276,Finance
+PYPL,PayPal Holdings Inc. Common Stock,44.23,39015525955.0,10668123,Industrials
+LYV,Live Nation Entertainment Inc. Common Stock,165.55,38994816611.0,1225997,Consumer Discretionary
+JBL,Jabil Inc. Common Stock,364.35,38439880326.0,800123,Technology
+CBRE,CBRE Group Inc Common Stock Class A,131.07,38379469010.0,1784161,Finance
+EME,EMCOR Group Inc. Common Stock,848.91,37725796397.0,252276,Industrials
+BTSGU,BrightSpring Health Services Inc. Tangible Equity Unit,194.055,37630834724.0,940,Health Care
+IRM,Iron Mountain Incorporated (Delaware)Common Stock REIT,126.46,37624971159.0,950191,Real Estate
+VIK,Viking Holdings Ltd Ordinary Shares,84.23,37548558065.0,2968397,Consumer Discretionary
+TRI,Thomson Reuters Corporation Common Shares,85.86,37452600881.0,877305,Consumer Discretionary
+ADM,Archer-Daniels-Midland Company Common Stock,77.52,37361269973.0,2468288,Consumer Staples
+HIG,The Hartford Insurance Group Inc. Common Stock,136.02,37287274136.0,1067288,Finance
+CCL,Carnival Corporation Ltd. Common Shares,25.98,37099851757.0,17155572,Consumer Discretionary
+HUM,Humana Inc. Common Stock,307.95,36972938925.0,677908,Health Care
+UI,Ubiquiti Inc. Common Stock,610.81,36967494739.0,189642,Technology
+WEC,WEC Energy Group Inc. Common Stock,113.41,36940549142.0,2125796,Utilities
+PPLC,PPL Corporation Corporate Units,48.86,36759838687.0,73256,Utilities
+TKO,TKO Group Holdings Inc. Class A Common Stock,191.5,36600684152.0,556763,Consumer Discretionary
+SYY,Sysco Corporation Common Stock,76.29,36480551164.0,3331594,Consumer Discretionary
+EQT,EQT Corporation Common Stock,57.92,36227685760.0,5201691,Energy
+PRU,Prudential Financial Inc. Common Stock,104.12,36129640000.0,1301594,Finance
+SATS,EchoStar  Corporation Common Stock,124.2,35994835210.0,10988302,Consumer Discretionary
+STRF,Strategy Inc 10.00% Series A Perpetual Strife Preferred Stock,101.49,35566954529.0,75745,Technology
+STRC,Strategy Inc Variable Rate Series A Perpetual Stretch Preferred Stock,99.3,34799473690.0,1719331,Technology
+PAYX,Paychex Inc. Common Stock,97.0,34754215457.0,2593382,Industrials
+HAL,Halliburton Company Common Stock,41.47,34643944070.0,9324962,Energy
+STLD,Steel Dynamics Inc.,240.03,34615393823.0,1187989,Industrials
+RBLX,Roblox Corporation Class A Common Stock,48.16,34481536359.0,10128388,Technology
+VG,Venture Global Inc. Class A common stock,13.83,34358671555.0,11162149,Utilities
+ZTS,Zoetis Inc. Class A Common Stock,81.32,34091630556.0,6327076,Health Care
+VMC,Vulcan Materials Company (Holding Company) Common Stock,260.65,33820610775.0,803707,Industrials
+KVUE,Kenvue Inc. Common Stock,17.53,33657751950.0,13689704,Consumer Discretionary
+WAT,Waters Corporation Common Stock,342.37,33615891176.0,478157,Industrials
+HBANP,Huntington Bancshares Incorporated Depositary Shares 4.500% Series H Non-Cumulative Perpetual Preferred Stock,16.5684,33586310418.0,52513,Finance
+ROP,Roper Technologies Inc. Common Stock,326.94,32993921351.0,1015509,Technology
+KMB,Kimberly-Clark Corporation Common Stock,99.14,32908566993.0,2265473,Consumer Discretionary
+Q,Qnity Electronics Inc. Common Stock,156.93,32851601755.0,1564895,Technology
+LVS,Las Vegas Sands Corp. Common Stock,49.43,32754162975.0,3826764,Consumer Discretionary
+SYM,Symbotic Inc. Class A Common Stock,54.03,32564249214.0,2922570,Industrials
+CPRT,Copart Inc. (DE) Common Stock,33.79,32550190431.0,15032878,Consumer Discretionary
+A,Agilent Technologies Inc. Common Stock,114.96,32487962362.0,2036535,Industrials
+UAL,United Airlines Holdings Inc. Common Stock,99.96,32444089971.0,4047167,Consumer Discretionary
+HBAN,Huntington Bancshares Incorporated Common Stock,15.92,32271918945.0,14028038,Finance
+RVMD,Revolution Medicines Inc. Common Stock,151.56,32221119781.0,1933236,Health Care
+MLM,Martin Marietta Materials Inc. Common Stock,536.48,32213424432.0,521280,Industrials
+WDAY,Workday Inc. Class A Common Stock,128.14,31994706505.0,10781733,Technology
+EL,Estee Lauder Companies Inc. (The) Common Stock,88.32,31953726893.0,8105787,Consumer Discretionary
+RPRX,Royalty Pharma plc Class A Ordinary Shares ,54.5,31382855118.0,3053951,Health Care
+MTB,M&T Bank Corporation Common Stock,213.18,31219157891.0,718832,Finance
+AXON,Axon Enterprise Inc. Common Stock,386.0,31112401722.0,1323964,Industrials
+ZM,Zoom Communications Inc. Class A Common Stock,105.64,31065725409.0,9626500,Technology
+NTRS,Northern Trust Corporation Common Stock,167.77,31045378475.0,728905,Finance
+AEE,Ameren Corporation Common Stock,111.29,30799687345.0,1816627,Utilities
+CQP,Cheniere Energy Partners LP Common Units,63.39,30684190857.0,45342,Utilities
+CASY,Casey's General Stores Inc. Common Stock,825.02,30491938931.0,488109,Consumer Discretionary
+VICI,VICI Properties Inc. Common Stock,28.5,30467360330.0,12160847,Real Estate
+FISV,Fiserv Inc. Common Stock,57.13,30464800220.0,6466052,Consumer Discretionary
+EXR,Extra Space Storage Inc Common Stock,143.3,30273692129.0,801867,Real Estate
+DTE,DTE Energy Company Common Stock,145.3,30226513879.0,1070380,Utilities
+MTZ,MasTec Inc. Common Stock,382.11,30193780433.0,654225,Industrials
+RMD,ResMed Inc. Common Stock,208.05,30178980691.0,1095707,Health Care
+ATO,Atmos Energy Corporation Common Stock,177.81,29680013550.0,1472584,Utilities
+AGNCN,AGNC Investment Corp. Depositary Shares Each Representing a 1/1000th Interest in a Share of 7.00% Series C Fixed-To-Floating Rate Cumulative Redeemable Preferred Stock,25.78,29593616632.0,8422,Real Estate
+RJF,Raymond James Financial Inc. Common Stock,151.46,29516984330.0,1336632,Finance
+MTSI,MACOM Technology Solutions Holdings Inc. Common Stock,385.98,29448642849.0,970541,Technology
+AGNCO,AGNC Investment Corp. Depositary Shares each representing a 1/1000th interest in a share of 6.50% Series E Fixed-to-Floating Cumulative Redeemable Preferred Stock,25.57,29352551485.0,8168,Real Estate
+DVN,Devon Energy Corporation Common Stock,47.22,29345113977.0,9118730,Energy
+ZS,Zscaler Inc. Common Stock,182.37,29323400506.0,3996539,Technology
+GEHC,GE HealthCare Technologies Inc. Common Stock ,64.23,29217699415.0,3181552,Health Care
+CNC,Centene Corporation Common Stock,59.14,29203154580.0,2917604,Health Care
+NTRA,Natera Inc. Common Stock,203.19,29099933469.0,1036323,Health Care
+AGNCZ,AGNC Investment Corp. Depositary Shares Each Representing a 1/1000th Interest in a Share of 8.75% Series H Fixed-Rate Cumulative Redeemable Preferred Stock,25.32,29065569167.0,13323,Uncategorized
+NRG,NRG Energy Inc. Common Stock,137.65,29042287596.0,2147843,Utilities
+P,Everpure Inc. Class A common stock,87.2,28963707069.0,5086470,Technology
+CPNG,Coupang Inc. Class A Common Stock,16.12,28936434920.0,16357451,Consumer Discretionary
+FTS,Fortis Inc. Common Shares,56.48,28755831558.0,523337,Utilities
+FICO,Fair Isaac Corporation Common Stock,1239.91,28754636258.0,303263,Consumer Discretionary
+TDY,Teledyne Technologies Incorporated Common Stock,620.45,28744913672.0,280858,Industrials
+AGNCP,AGNC Investment Corp. Depositary Shares Each Representing a 1/1000th Interest in a Share of 6.125% Series F Fixed-to-Floating Rate Cumulative Redeemable Preferred Stock,24.97,28663793922.0,33330,Real Estate
+BIIB,Biogen Inc. Common Stock,193.76,28606167790.0,892915,Health Care
+AGNCM,AGNC Investment Corp. Depositary Shares rep 6.875% Series D Fixed-to-Floating Cumulative Redeemable Preferred Stock,24.88,28560480287.0,9911,Real Estate
+TWLO,Twilio Inc. Class A Common Stock,187.88,28515272817.0,1322858,Technology
+AGNCL,AGNC Investment Corp. Depositary Shares Each Representing a 1/1000th Interest in a Share of 7.75% Series G Fixed-Rate Reset Cumulative Redeemable Preferred Stock,24.84,28514563116.0,6528,Real Estate
+DOV,Dover Corporation Common Stock,209.9,28265430799.0,566597,Industrials
+VRSN,VeriSign Inc. Common Stock,310.0,28210000000.0,896472,Technology
+KHC,The Kraft Heinz Company Common Stock,23.79,28209650008.0,11189605,Consumer Staples
+CRCL,Circle Internet Group Inc. Class A Common Stock,113.12,28118920514.0,9743239,Finance
+IQV,IQVIA Holdings Inc. Common Stock,167.9,28022510000.0,1790977,Health Care
+CNP,CenterPoint Energy Inc (Holding Co) Common Stock,42.83,28018078828.0,4955569,Utilities
+TPR,Tapestry Inc. Common Stock,138.49,27981172442.0,1321300,Consumer Discretionary
+OTIS,Otis Worldwide Corporation Common Stock ,72.77,27923018851.0,3585892,Technology
+DXCM,DexCom Inc. Common Stock,72.1,27821441642.0,6727078,Health Care
+IR,Ingersoll Rand Inc. Common Stock,70.91,27749694899.0,4447995,Industrials
+TPL,Texas Pacific Land Corporation Common Stock,402.03,27729789691.0,288311,Energy
+FSLR,First Solar Inc. Common Stock,257.85,27706849650.0,2476672,Technology
+NTAP,NetApp Inc. Common Stock,139.36,27499964544.0,6667696,Technology
+EIX,Edison International Common Stock,71.18,27389632720.0,1767618,Utilities
+PPL,PPL Corporation Common Stock,36.32,27325365148.0,6548574,Utilities
+RDDT,Reddit Inc. Class A Common Stock,141.67,27262287559.0,7832411,Technology
+CW,Curtiss-Wright Corporation Common Stock,731.24,27012856763.0,191482,Technology
+FOXA,Fox Corporation Class A Common Stock,63.98,26883520434.0,1557563,Industrials
+FE,FirstEnergy Corp. Common Stock,46.31,26787147714.0,4452035,Utilities
+CFG,Citizens Financial Group Inc. Common Stock,62.89,26595045332.0,2741202,Finance
+ES,Eversource Energy (D/B/A) Common Stock,70.0,26325601750.0,2578914,Utilities
+MDB,MongoDB Inc. Class A Common Stock,326.13,26253443475.0,1263393,Technology
+XYL,Xylem Inc. Common Stock New,110.28,26212838408.0,1540576,Industrials
+VEEV,Veeva Systems Inc. Class A Common Stock,160.17,26124296404.0,2018376,Technology
+CINF,Cincinnati Financial Corporation Common Stock,168.1,26002841330.0,332382,Finance
+DOW,Dow Inc. Common Stock ,36.01,25953899182.0,9010408,Industrials
+FTAI,FTAI Aviation Ltd. Common Stock,252.13,25864244730.0,1191968,Industrials
+STRK,Strategy Inc 8.00% Series A Perpetual Strike Preferred Stock,73.78,25856043996.0,65889,Technology
+AVB,AvalonBay Communities Inc. Common Stock,185.65,25826155610.0,1311866,Real Estate
+STRD,Strategy Inc 10.00% Series A Perpetual Stride Preferred Stock,73.59,25789458900.0,74940,Technology
+EXPE,Expedia Group Inc. Common Stock,214.65,25762738828.0,1550487,Consumer Discretionary
+STZ,Constellation Brands Inc. Common Stock,149.5,25743670817.0,1403930,Consumer Staples
+ROL,Rollins Inc. Common Stock,53.46,25739047424.0,2083160,Consumer Discretionary
+WRB,W.R. Berkley Corporation Common Stock,67.54,25143570479.0,1636190,Finance
+HUBB,Hubbell Inc Common Stock,475.01,25100372493.0,824784,Technology
+TW,Tradeweb Markets Inc. Class A Common Stock,106.2,25065963430.0,1928498,Finance
+CTSH,Cognizant Technology Solutions Corporation Class A Common Stock,52.75,24996614490.0,9235794,Technology
+EQR,Equity Residential Common Shares of Beneficial Interest,66.2,24803268857.0,2034973,Real Estate
+AWK,American Water Works Company Inc. Common Stock,125.2,24449121229.0,1121432,Utilities
+JBHT,J.B. Hunt Transport Services Inc. Common Stock,258.77,24401804760.0,839622,Industrials
+SYF,Synchrony Financial Common Stock,71.83,24161474483.0,2992594,Finance
+UTHR,United Therapeutics Corporation Common Stock,568.43,24127996439.0,281482,Health Care
+FOX,Fox Corporation Class B Common Stock,57.24,24051464671.0,1212653,Industrials
+PPG,PPG Industries Inc. Common Stock,107.78,24024162000.0,1459767,Consumer Discretionary
+XPO,XPO Inc. Common Stock,202.92,23824833345.0,1136369,Consumer Discretionary
+IONQ,IonQ Inc. Common Stock,63.64,23754899491.0,52492757,Technology
+RF,Regions Financial Corporation Common Stock,27.83,23749552543.0,9709592,Finance
+FITBM,Fifth Third Bancorp Depositary Shares Representing a 1/40th Ownership Interest in a Share of 6.875% Fixed-Rate Reset Non-Cumulative Perpetual Preferred Stock Series M,26.06,23618478941.0,6683,Finance
+SOJC,Southern Company (The) Series 2017B 5.25% Junior Subordinated Notes due December 1 2077,21.39,23530014036.0,13546,Utilities
+EXE,Expand Energy Corporation Common Stock,97.94,23430073471.0,1468053,Energy
+BG,Bunge Limited Common Shares,120.71,23419926662.0,1821227,Consumer Staples
+KEY,KeyCorp Common Stock,21.56,23375905833.0,6087268,Finance
+DRI,Darden Restaurants Inc. Common Stock,203.51,23309018461.0,1503929,Consumer Discretionary
+DG,Dollar General Corporation Common Stock,105.65,23266910708.0,2435163,Consumer Discretionary
+MKL,Markel Group Inc. Common Stock,1857.89,23249096672.0,66805,Finance
+FITBI,Fifth Third Bancorp Depositary Shares,25.59,23192512513.0,35165,Finance
+HPQ,HP Inc. Common Stock,25.24,23164889664.0,48645936,Technology
+FCNCA,First Citizens BancShares Inc. Class A Common Stock,1991.55,23076038070.0,83541,Finance
+INSM,Insmed Incorporated Common Stock,106.24,23027780394.0,2432717,Health Care
+CMS,CMS Energy Corporation Common Stock,74.53,23023777937.0,2154138,Utilities
+TSN,Tyson Foods Inc. Common Stock,65.05,22906017600.0,2031576,Consumer Staples
+RL,Ralph Lauren Corporation Common Stock,377.78,22869446103.0,885578,Industrials
+LPLA,LPL Financial Holdings Inc. Common Stock,285.78,22857502017.0,845447,Finance
+NI,NiSource Inc Common Stock,47.85,22833806063.0,2489793,Utilities
+CHD,Church & Dwight Company Inc. Common Stock,96.25,22805821693.0,1038328,Consumer Discretionary
+CPAY,Corpay Inc. Common Stock,347.9,22739411620.0,419941,Consumer Discretionary
+WSM,Williams-Sonoma Inc. Common Stock (DE),192.5,22665463975.0,1001739,Consumer Discretionary
+FIS,Fidelity National Information Services Inc. Common Stock,43.56,22515255818.0,3860785,Consumer Discretionary
+STRL,Sterling Infrastructure Inc. Common Stock,732.94,22490963125.0,547980,Industrials
+ULTA,Ulta Beauty Inc. Common Stock,515.04,22435356657.0,481339,Consumer Discretionary
+PFG,Principal Financial Group Inc Common Stock,103.85,22432886078.0,724256,Finance
+VRSK,Verisk Analytics Inc. Common Stock,171.11,22419147042.0,1660250,Industrials
+L,Loews Corporation Common Stock,108.87,22402057204.0,701443,Finance
+WST,West Pharmaceutical Services Inc. Common Stock,316.42,22354312010.0,533959,Health Care
+FFIV,F5 Inc. Common Stock,393.63,22208308197.0,451386,Telecommunications
+FWONK,Liberty Media Corporation Series C Liberty Formula One Common Stock,88.56,22193641500.0,1594697,Industrials
+PHM,PulteGroup Inc. Common Stock,116.43,22178326080.0,1294992,Consumer Discretionary
+TROW,T. Rowe Price Group Inc. Common Stock,103.39,22153024394.0,2006052,Finance
+ATI,ATI Inc. Common Stock,162.29,22147785598.0,1682002,Industrials
+LEN,Lennar Corporation Class A Common Stock,88.86,21886066583.0,2179034,Consumer Discretionary
+ILMN,Illumina Inc. Common Stock,144.41,21849233000.0,906001,Health Care
+AFRM,Affirm Holdings Inc. Class A Common Stock,65.22,21842084409.0,5545790,Finance
+SBAC,SBA Communications Corporation Class A Common Stock,205.57,21803374405.0,632068,Real Estate
+MKSI,MKS Inc. Common Stock,320.62,21655998640.0,835795,Industrials
+DGX,Quest Diagnostics Incorporated Common Stock,195.21,21609049905.0,871520,Health Care
+CRS,Carpenter Technology Corporation Common Stock,434.12,21569517881.0,545795,Industrials
+SOJD,Southern Company (The) Series 2020A 4.95% Junior Subordinated Notes due January 30 2080,19.48,21428923488.0,57322,Utilities
+AKAM,Akamai Technologies Inc. Common Stock,147.23,21405099951.0,3736359,Consumer Discretionary
+SMCI,Super Micro Computer Inc. Common Stock,35.58,21398469590.0,39371033,Technology
+OMC,Omnicom Group Inc. Common Stock,74.93,21355514266.0,2525438,Consumer Discretionary
+VLTO,Veralto Corp Common Stock ,86.8,21318016289.0,1559354,Industrials
+LH,Labcorp Holdings Inc. Common Stock,259.93,21314260000.0,543427,Health Care
+FITBP,Fifth Third Bancorp Depositary Shares each representing 1/40th share of Fifth Third 6.00% Non-Cumulative Perpetual Class B Preferred Stock Series A,23.51,21307384493.0,2518,Finance
+STE,STERIS plc (Ireland) Ordinary Shares,216.57,21240108164.0,645596,Health Care
+WWD,Woodward Inc. Common Stock,351.36,20935034041.0,561158,Energy
+ULS,UL Solutions Inc. Class A Common Stock,102.85,20730766378.0,603723,Health Care
+EXPD,Expeditors International of Washington Inc. Common Stock,158.48,20727778758.0,1261973,Industrials
+DKS,Dick's Sporting Goods Inc Common Stock,231.24,20684163867.0,1268738,Consumer Discretionary
+ENTG,Entegris Inc. Common Stock,135.28,20630200000.0,2227605,Industrials
+CHRW,C.H. Robinson Worldwide Inc. Common Stock,174.23,20537020108.0,1512967,Industrials
+FWONA,Liberty Media Corporation Series A Liberty Formula One Common Stock,81.91,20527113542.0,157925,Industrials
+BURL,Burlington Stores Inc. Common Stock,324.51,20389051242.0,1030873,Consumer Discretionary
+ALB,Albemarle Corporation Common Stock,171.58,20235227419.0,1676116,Industrials
+CHTR,Charter Communications Inc. Class A Common Stock New,145.15,20173605546.0,2100907,Telecommunications
+AQNB,Algonquin Power & Utilities Corp. 6.20% Fixed-to-Floating Subordinated Notes Series 2019-A due July 1 2079,26.11,20053132776.0,5213,Utilities
+GPN,Global Payments Inc. Common Stock,73.26,20039797323.0,2094383,Consumer Discretionary
+SOFI,SoFi Technologies Inc. Common Stock  ,15.62,20036417544.0,57928347,Finance
+LUV,Southwest Airlines Company Common Stock,40.86,19971293913.0,7028209,Consumer Discretionary
+DD,DuPont de Nemours Inc. Common Stock,48.12,19725413245.0,2276652,Industrials
+TTMI,TTM Technologies Inc. Common Stock,189.92,19723203205.0,3076928,Technology
+LSCC,Lattice Semiconductor Corporation Common Stock,143.22,19622265280.0,1748650,Technology
+NXT,Nextpower Inc. Class A Common Stock,130.5,19610818596.0,2803274,Industrials
+BRO,Brown & Brown Inc. Common Stock,57.82,19597964167.0,2550312,Finance
+EFX,Equifax Inc. Common Stock,164.04,19532637972.0,1055081,Finance
+INCY,Incyte Corp. Common Stock,97.16,19408462796.0,879962,Health Care
+VTRS,Viatris Inc. Common Stock,16.65,19389801689.0,7362454,Health Care
+EVRG,Evergy Inc. Common Stock,83.94,19349263319.0,1609909,Utilities
+PKG,Packaging Corporation of America Common Stock,215.91,19237288874.0,475707,Consumer Discretionary
+SITM,SiTime Corporation Common Stock,728.56,19231673008.0,398835,Technology
+IFF,International Flavors & Fragrances Inc. Common Stock,75.28,19219245447.0,1298376,Industrials
+LNT,Alliant Energy Corporation Common Stock,73.95,19099586886.0,1950735,Utilities
+SNX,TD SYNNEX Corporation Common Stock,237.34,19080022013.0,494583,Technology
+SNA,Snap-On Incorporated Common Stock,366.65,18993172501.0,299153,Consumer Discretionary
+AA,Alcoa Corporation Common Stock ,71.38,18836459278.0,6941423,Industrials
+RS,Reliance Inc. Common Stock,367.0,18734807574.0,247180,Industrials
+CF,CF Industries Holdings Inc. Common Stock,121.7,18696682646.0,1618707,Industrials
+RGLD,Royal Gold Inc. Common Stock,220.29,18695263755.0,410746,Industrials
+MRNA,Moderna Inc. Common Stock,46.88,18601339822.0,4218047,Health Care
+BWXT,BWX Technologies Inc. Common Stock,202.91,18589528429.0,456850,Industrials
+DUKB,Duke Energy Corporation 5.625% Junior Subordinated Debentures due 2078,23.78,18538798040.0,16038,Utilities
+ROKU,Roku Inc. Class A Common Stock,125.55,18529119097.0,1595356,Telecommunications
+DLTR,Dollar Tree Inc. Common Stock,94.98,18495019062.0,2397023,Consumer Discretionary
+SOJE,Southern Company (The) Series 2020C 4.20% Junior Subordinated Notes due October 15 2060,16.89,18487215298.0,53143,Basic Materials
+CDE,Coeur Mining Inc. Common Stock,17.63,18238424805.0,13060735,Basic Materials
+IOT,Samsara Inc. Class A Common Stock,31.15,18151419054.0,3352727,Technology
+WES,Western Midstream Partners LP Common Units Representing Limited Partner Interests,46.01,18117879407.0,1355539,Utilities
+WMG,Warner Music Group Corp. Class A Common Stock,34.72,18110491132.0,3104952,Consumer Discretionary
+APG,APi Group Corporation Common Stock,41.63,18035281182.0,1499789,Consumer Discretionary
+FTV,Fortive Corporation Common Stock ,59.13,18026432172.0,2052261,Industrials
+GIS,General Mills Inc. Common Stock,33.69,17979720234.0,6602389,Consumer Staples
+RIVN,Rivian Automotive Inc. Class A Common Stock,14.22,17923141031.0,27029592,Industrials
+ESS,Essex Property Trust Inc. Common Stock,276.7,17781535022.0,368173,Real Estate
+USFD,US Foods Holding Corp. Common Stock,80.47,17721236658.0,1803467,Consumer Discretionary
+RBC,RBC Bearings Incorporated Common Stock,559.95,17714219272.0,282298,Industrials
+WCC,WESCO International Inc. Common Stock,363.57,17707637584.0,393848,Consumer Discretionary
+ITT,ITT Inc. Common Stock ,195.01,17433894000.0,434065,Industrials
+BR,Broadridge Financial Solutions Inc. Common Stock,150.49,17405417116.0,896003,Consumer Discretionary
+INVH,Invitation Homes Inc. Common Stock,29.29,17399488891.0,4077877,Finance
+PTC,PTC Inc. Common Stock,148.23,17121423400.0,929382,Technology
+PR,Permian Resources Corporation Class A Common Stock,20.44,17114169255.0,7376430,Energy
+WY,Weyerhaeuser Company Common Stock,23.66,17059877380.0,4040075,Real Estate
+PAA,Plains All American Pipeline L.P. Common Units representing Limited Partner Interests,24.15,17038590144.0,2727688,Energy
+TLN,Talen Energy Corporation Common Stock,372.45,16907370357.0,847817,Utilities
+EWBC,East West Bancorp Inc. Common Stock,123.12,16866979777.0,818491,Finance
+LII,Lennox International Inc. Common Stock,484.64,16865456492.0,367158,Industrials
+FITBO,Fifth Third Bancorp Depositary Shares each representing a 1/1000th ownership interest in a share of Non-Cumulative Perpetual Preferred Stock Series K,18.58,16839268562.0,13173,Finance
+VNOM,Viper Energy Inc. Class A Common Stock,46.89,16834708602.0,1672136,Energy
+WPC,W. P. Carey Inc. REIT,74.48,16589608540.0,1206370,Real Estate
+TSCO,Tractor Supply Company Common Stock,31.62,16583096858.0,7565910,Consumer Discretionary
+IP,International Paper Company Common Stock,31.29,16568586116.0,6173654,Basic Materials
+ZBH,Zimmer Biomet Holdings Inc. Common Stock,85.5,16541042211.0,1809764,Health Care
+DOCN,DigitalOcean Holdings Inc. Common Stock,158.46,16537548121.0,2269723,Technology
+LOGI,Logitech International S.A. Ordinary Shares,112.63,16510312988.0,1761602,Technology
+H,Hyatt Hotels Corporation Class A Common Stock,174.15,16398397111.0,779280,Consumer Discretionary
+CG,The Carlyle Group Inc. Common Stock,45.43,16353638219.0,2306891,Finance
+AMKR,Amkor Technology Inc. Common Stock,65.75,16297618059.0,5884928,Technology
+NVR,NVR Inc. Common Stock,6036.99,16295598811.0,19596,Consumer Discretionary
+KIM,Kimco Realty Corporation (HC) Common Stock,24.11,16259537885.0,3371070,Real Estate
+NWS,News Corporation Class B Common Stock,29.68,16248219837.0,1022361,Consumer Discretionary
+OKTA,Okta Inc. Class A Common Stock,92.24,16215893095.0,3006949,Technology
+NDSN,Nordson Corporation Common Stock,289.9,16171665060.0,558522,Industrials
+SSNC,SS&C Technologies Holdings Inc. Common Stock,67.04,16145513975.0,1951287,Technology
+BEN,Franklin Resources Inc. Common Stock,31.02,16119144765.0,2563275,Finance
+TPG,TPG Inc. Class A Common Stock,41.62,15995079757.0,1785948,Finance
+TXT,Textron Inc. Common Stock,91.83,15968225125.0,843869,Industrials
+GNRC,Generac Holdlings Inc. Common Stock,270.14,15902785485.0,1205288,Consumer Discretionary
+SN,SharkNinja Inc. Ordinary Shares,112.03,15854528059.0,1131562,Consumer Discretionary
+LDOS,Leidos Holdings Inc. Common Stock,126.01,15850226571.0,775888,Technology
+GH,Guardant Health Inc. Common Stock,118.95,15772761555.0,2819859,Health Care
+NBIX,Neurocrine Biosciences Inc. Common Stock,156.7,15756182336.0,758818,Health Care
+SUI,Sun Communities Inc. Common Stock,127.75,15742729207.0,947521,Real Estate
+NLY,Annaly Capital Management Inc. Common Stock,21.45,15711711144.0,4824123,Real Estate
+OWL,Blue Owl Capital Inc. Class A Common Stock,10.06,15684046109.0,15726500,Finance
+YUMC,Yum China Holdings Inc. Common Stock,44.56,15558006852.0,1352518,Consumer Discretionary
+LAMR,Lamar Advertising Company Class A Common Stock,153.1,15535837963.0,523567,Real Estate
+RMBS,Rambus Inc. Common Stock,142.98,15461423542.0,1600991,Technology
+IEX,IDEX Corporation Common Stock,208.78,15452862557.0,673011,Industrials
+DTM,DT Midstream Inc. Common Stock ,151.12,15416373512.0,523626,Utilities
+PL,Planet Labs PBC Class A Common Stock,44.35,15351709347.0,9787659,Technology
+HST,Host Hotels & Resorts Inc. Common Stock,22.38,15327598309.0,7644036,Real Estate
+MAA,Mid-America Apartment Communities Inc. Common Stock,131.14,15262702934.0,863943,Real Estate
+WSO,Watsco Inc. Common Stock,375.17,15253487031.0,436593,Consumer Discretionary
+CLH,Clean Harbors Inc. Common Stock,286.92,15162583501.0,338621,Industrials
+DECK,Deckers Outdoor Corporation Common Stock,106.67,15141803407.0,5163678,Consumer Discretionary
+BALL,Ball Corporation Common Stock,56.51,15045590337.0,1659023,Industrials
+GEN,Gen Digital Inc. Common Stock,24.82,15032574871.0,5733604,Technology
+THC,Tenet Healthcare Corporation Common Stock,173.78,14968887860.0,1005543,Health Care
+APOS,Apollo Global Management Inc. 7.625% Fixed-Rate Resettable Junior Subordinated Notes due 2053,26.14,14887625844.0,12727,Finance
+MLI,Mueller Industries Inc. Common Stock,133.39,14749014068.0,491213,Industrials
+PFGC,Performance Food Group Company Common Stock,93.63,14708322749.0,902279,Consumer Discretionary
+PNFP,Pinnacle Financial Partners Inc. Common stock,97.15,14680026786.0,689739,Finance
+KKRS,KKR Group Finance Co. IX LLC 4.625% Subordinated Notes due 2061,16.32,14653286397.0,33799,Finance
+SMTC,Semtech Corporation Common Stock,156.78,14598491467.0,6408627,Technology
+AAOI,Applied Optoelectronics Inc. Common Stock,181.49,14563259783.0,10259961,Technology
+REG,Regency Centers Corporation Common Stock,78.84,14435350924.0,996960,Real Estate
+LECO,Lincoln Electric Holdings Inc. Common Shares,263.43,14432568387.0,268474,Industrials
+SUN,Sunoco LP Common Units representing limited partner interests,70.31,14401086287.0,392333,Energy
+VLYPN,Valley National Bancorp 8.250% Fixed-Rate Reset Non-Cumulative Perpetual Preferred Stock Series C,25.85,14324298706.0,6926,Finance
+OHI,Omega Healthcare Investors Inc. Common Stock,47.9,14264715800.0,2013864,Real Estate
+NWSA,News Corporation Class A Common Stock,25.89,14173396616.0,3844096,Consumer Discretionary
+ARXS,Arxis Inc. Class A Common Stock,34.8,14171499322.0,321350,Industrials
+CDW,CDW Corporation Common Stock,110.82,14157637440.0,1519870,Technology
+SLMBP,SLM Corporation Floating Rate Non-Cumulative Preferred Stock Series B,74.97,14138816835.0,173,Finance
+BEPC,Brookfield Renewable Corporation Brookfield Renewable Corporation Class A Subordinate Voting Shares,37.5,14133233775.0,1345847,Utilities
+SGI,Somnigroup International Inc. Common Stock,66.89,14069684339.0,2461776,Consumer Discretionary
+RGA,Reinsurance Group of America Incorporated Common Stock,214.04,14022437409.0,296683,Finance
+VLYPP,Valley National Bancorp 6.25% Fixed-to-Floating Rate Non-Cumulative Perpetual Preferred Stock Series A,25.165,13944718644.0,1391,Finance
+VLYPO,Valley National Bancorp 5.50% Fixed-to-Floating Rate Non-Cumulative Perpetual Preferred Stock Series B,25.06,13886534839.0,8275,Finance
+TME,Tencent Music Entertainment Group American Depositary Shares each representing two Class A Ordinary Shares,8.81,13866098645.0,15138114,Consumer Discretionary
+AUR,Aurora Innovation Inc. Class A Common Stock,7.07,13865705839.0,25495626,Technology
+CSGP,CoStar Group Inc. Common Stock,33.95,13863676524.0,4615862,Finance
+MOD,Modine Manufacturing Company Common Stock,260.52,13737531442.0,1346724,Consumer Discretionary
+APA,APA Corporation Common Stock,38.8,13714644808.0,3872722,Energy
+RBRK,Rubrik Inc. Class A Common Stock,66.59,13704876979.0,2428346,Technology
+TRU,TransUnion Common Stock,70.66,13623248000.0,1568029,Finance
+DOC,Healthpeak Properties Inc. Common Stock,19.73,13602250720.0,5630963,Real Estate
+MAS,Masco Corporation Common Stock,67.26,13568658233.0,2337717,Industrials
+J,Jacobs Solutions Inc. Common Stock,114.69,13542696013.0,892986,Industrials
+GLPI,Gaming and Leisure Properties Inc. Common Stock,47.78,13541847066.0,1318308,Real Estate
+JLL,Jones Lang LaSalle Incorporated Common Stock,291.69,13532541892.0,235902,Finance
+BBIO,BridgeBio Pharma Inc. Common Stock,69.12,13527316362.0,1826499,Health Care
+CSL,Carlisle Companies Incorporated Common Stock,333.8,13507242369.0,308487,Industrials
+UNM,Unum Group Common Stock,84.52,13504287382.0,913468,Finance
+BWA,BorgWarner Inc. Common Stock,65.82,13500665417.0,4194153,Consumer Discretionary
+ARMK,Aramark Common Stock,51.26,13478999691.0,2005489,Consumer Discretionary
+GPC,Genuine Parts Company Common Stock,97.87,13469314219.0,959079,Consumer Discretionary
+TOST,Toast Inc. Class A Common Stock,23.16,13432800000.0,7536360,Technology
+SREA,DBA Sempra 5.750% Junior Subordinated Notes due 2079,21.205,13425858279.0,13492,Utilities
+EVR,Evercore Inc. Class A Common Stock,346.12,13388781362.0,280671,Finance
+RRX,Regal Rexnord Corporation Common Stock,200.78,13365838867.0,482374,Consumer Discretionary
+ARCC,Ares Capital Corporation Common Stock,18.59,13348044689.0,4518864,Finance
+SOLV,Solventum Corporation Common Stock,76.83,13305013123.0,1629328,Health Care
+TYL,Tyler Technologies Inc. Common Stock,313.25,13208955279.0,358075,Technology
+SANM,Sanmina Corporation Common Stock,246.44,13208625813.0,781464,Technology
+IESC,IES Holdings Inc. Common Stock,659.65,13142792060.0,141457,Industrials
+TRMB,Trimble Inc. Common Stock,56.34,13133502980.0,2181618,Industrials
+APLD,Applied Digital Corporation Common Stock,45.87,13108248754.0,22155321,Finance
+FNF,Fidelity National Financial Inc. Common Stock,48.61,13083748019.0,1027792,Finance
+ONTO,Onto Innovation Inc. Common Stock,262.25,13045250446.0,813041,Industrials
+NIO,NIO Inc. American depositary shares each  representing one Class A ordinary share,5.2,13029468514.0,87607830,Industrials
+BBY,Best Buy Co. Inc. Common Stock,61.63,12985144375.0,5502130,Consumer Discretionary
+SOLS,Solstice Advanced Materials Inc. Common Stock ,81.76,12983837360.0,1877552,Industrials
+ALLY,Ally Financial Inc. Common Stock,42.35,12981251676.0,2566047,Finance
+PEN,Penumbra Inc. Common Stock,328.69,12927846083.0,508539,Health Care
+SMMT,Summit Therapeutics Inc. Common Stock ,16.62,12899823160.0,6890530,Health Care
+RPM,RPM International Inc. Common Stock,100.9,12877516574.0,798487,Consumer Discretionary
+CET,Central Securities Corporation Common Stock,53.15,12863639380.0,31333,Finance
+MKC,McCormick & Company Incorporated Common Stock,47.8,12845053566.0,2680272,Consumer Staples
+DVA,DaVita Inc. Common Stock,198.52,12744984000.0,628742,Health Care
+TOL,Toll Brothers Inc. Common Stock,134.33,12721991310.0,1047862,Consumer Discretionary
+CRBG,Corebridge Financial Inc. Common Stock,27.74,12669776777.0,5740011,Finance
+HII,Huntington Ingalls Industries Inc. Common Stock,320.63,12634113818.0,286480,Industrials
+AIZ,Assurant Inc. Common Stock,254.82,12625728860.0,267651,Finance
+EXEL,Exelixis Inc. Common Stock,50.15,12605457412.0,1543315,Health Care
+DINO,HF Sinclair Corporation Common Stock,69.91,12603055801.0,1191866,Energy
+GGG,Graco Inc. Common Stock,75.63,12552173227.0,996231,Industrials
+NTNX,Nutanix Inc. Class A Common Stock,47.12,12496794011.0,5829260,Technology
+IONS,Ionis Pharmaceuticals Inc. Common Stock,75.56,12487238731.0,1579206,Health Care
+PNW,Pinnacle West Capital Corporation Common Stock,102.94,12475006868.0,948232,Utilities
+HAS,Hasbro Inc. Common Stock,88.1,12465329965.0,2235327,Consumer Discretionary
+DKNG,DraftKings Inc. Class A Common Stock,25.12,12462755883.0,9806594,Consumer Discretionary
+SWKS,Skyworks Solutions Inc. Common Stock,82.42,12396459470.0,5335820,Technology
+MEDP,Medpace Holdings Inc. Common Stock,432.8,12360633399.0,233334,Health Care
+AEIS,Advanced Energy Industries Inc. Common Stock,324.86,12354639233.0,606485,Technology
+UDR,UDR Inc. Common Stock,38.01,12350043971.0,4736127,Real Estate
+DY,Dycom Industries Inc. Common Stock,411.2,12343647909.0,442990,Industrials
+ELS,Equity Lifestyle Properties Inc. Common Stock,63.55,12324731493.0,1150363,Real Estate
+VICR,Vicor Corporation Common Stock,267.99,12215361262.0,474541,Technology
+AVY,Avery Dennison Corporation Common Stock,159.66,12212454869.0,468952,Consumer Discretionary
+COO,The Cooper Companies Inc. Common Stock,62.55,12204405595.0,1536844,Health Care
+ZBRA,Zebra Technologies Corporation Class A Common Stock,255.55,12172713326.0,1383741,Industrials
+SAIA,Saia Inc. Common Stock,456.23,12168207963.0,367196,Industrials
+AXSM,Axsome Therapeutics Inc. Common Stock,235.97,12142960983.0,674617,Health Care
+FIVE,Five Below Inc. Common Stock,219.5,12137236916.0,805378,Consumer Discretionary
+GL,Globe Life Inc. Common Stock,156.28,12134323249.0,398984,Finance
+NYT,New York Times Company (The) Common Stock,74.96,12133227917.0,1319364,Consumer Discretionary
+QXO,QXO Inc. Common Stock,16.67,12088551060.0,9509935,Consumer Discretionary
+DT,Dynatrace Inc. Common Stock,41.21,12011714957.0,4502255,Technology
+FIG,Figma Inc. Class A Common Stock,22.71,11999431973.0,16841658,Technology
+IVZ,Invesco Ltd Common Stock,27.05,11991173814.0,2603690,Finance
+EQH,Equitable Holdings Inc. Common Stock,42.58,11987095626.0,2701707,Finance
+GDDY,GoDaddy Inc. Class A Common Stock,90.46,11977794760.0,1378066,Technology
+MDGL,Madrigal Pharmaceuticals Inc. Common Stock,517.26,11925770174.0,160867,Health Care
+HUT,Hut 8 Corp. Common Stock,105.9,11923716461.0,3304991,Finance
+CNA,CNA Financial Corporation Common Stock,44.05,11916909271.0,400582,Finance
+SWK,Stanley Black & Decker Inc. Common Stock,76.46,11886132423.0,982933,Consumer Discretionary
+GWRE,Guidewire Software Inc. Common Stock,140.26,11874056742.0,1552379,Technology
+AGNC,AGNC Investment Corp. Common Stock,10.21,11720357867.0,11676708,Real Estate
+ALGN,Align Technology Inc. Common Stock,163.61,11717441758.0,844545,Health Care
+PSKY,Paramount Skydance Corporation Class B Common Stock,10.46,11706550187.0,5042243,Industrials
+HRL,Hormel Foods Corporation Common Stock,21.24,11688036557.0,4567097,Consumer Staples
+COKE,Coca-Cola Consolidated Inc. Common Stock,175.53,11684030526.0,1022007,Consumer Staples
+TXRH,Texas Roadhouse Inc. Common Stock,177.57,11671607736.0,718939,Consumer Discretionary
+LFUS,Littelfuse Inc. Common Stock,460.48,11645034514.0,298905,Energy
+AMH,American Homes 4 Rent Common Shares of Beneficial Interest,32.27,11636419754.0,2146446,Real Estate
+WBS,Webster Financial Corporation Common Stock,71.8,11633502556.0,5440782,Finance
+VIAV,Viavi Solutions Inc. Common Stock,49.51,11580778644.0,4586164,Technology
+GMED,Globus Medical Inc. Class A Common Stock,84.81,11512501731.0,1808873,Health Care
+CLX,Clorox Company (The) Common Stock,95.11,11500829694.0,1631706,Consumer Discretionary
+FHN,First Horizon Corporation Common Stock,24.23,11499989609.0,2940343,Finance
+BLD,TopBuild Corp. Common Stock,407.97,11481157423.0,332521,Consumer Discretionary
+MP,MP Materials Corp. Common Stock,64.46,11475310883.0,6837065,Basic Materials
+OKLO,Oklo Inc. Class A common stock,65.88,11462526224.0,11375052,Utilities
+KNX,Knight-Swift Transportation Holdings Inc.,70.12,11394079280.0,2733924,Industrials
+HL,Hecla Mining Company Common Stock,16.98,11388696603.0,11827035,Industrials
+AR,Antero Resources Corporation Common Stock,36.75,11386473000.0,4634010,Energy
+AFG,American Financial Group Inc. Common Stock,136.69,11357036685.0,227440,Finance
+WLK,Westlake Corporation Common Stock,88.6,11351692838.0,829712,Industrials
+AIT,Applied Industrial Technologies Inc. Common Stock,307.1,11350275041.0,180074,Consumer Discretionary
+BTSG,BrightSpring Health Services Inc. Common Stock,58.5,11344226283.0,1447399,Health Care
+WULF,TeraWulf Inc. Common Stock,22.82,11308054959.0,20770423,Technology
+ALLE,Allegion plc Ordinary Shares,130.43,11208614350.0,642879,Consumer Discretionary
+XE,X-Energy Inc. Class A Common Stock,28.32,11193441711.0,2861659,Industrials
+GLXY,Galaxy Digital Inc. Class A Common Stock,28.65,11190985955.0,4063764,Finance
+U,Unity Software Inc. Common Stock,25.57,11162199873.0,7794311,Technology
+SF,Stifel Financial Corporation Common Stock,72.59,11135434412.0,1222861,Finance
+ARW,Arrow Electronics Inc. Common Stock,217.33,11112940484.0,434992,Technology
+CACI,CACI International Inc. Class A Common Stock,501.35,11075475762.0,186998,Technology
+BJ,BJ's Wholesale Club Holdings Inc. Common Stock,86.64,11063271962.0,7351811,Consumer Discretionary
+AAON,AAON Inc. Common Stock,134.6,11025316166.0,944215,Industrials
+SJM,The J.M. Smucker Company Common Stock,103.36,11023170252.0,1117849,Consumer Staples
+CGNX,Cognex Corporation Common Stock,66.09,10998661517.0,2039797,Industrials
+SEIC,SEI Investments Company Common Stock,90.53,10888312517.0,527792,Finance
+FRVO,Fervo Energy Company Class A common stock,38.35,10874615471.0,3402001,Utilities
+ELAN,Elanco Animal Health Incorporated Common Stock,21.73,10853039439.0,5829023,Health Care
+PAG,Penske Automotive Group Inc. Common Stock,164.73,10830874776.0,183163,Consumer Discretionary
+RVTY,Revvity Inc. Common Stock,96.95,10815719992.0,942923,Industrials
+CCK,Crown Holdings Inc.,96.71,10807015330.0,1042212,Industrials
+PINS,Pinterest Inc. Class A Common Stock,19.29,10805434838.0,12783668,Technology
+CPT,Camden Property Trust Common Stock,107.47,10802855598.0,1251879,Real Estate
+QBTS,D-Wave Quantum Inc. Common Shares,29.4,10782085469.0,141270753,Technology
+BMNR,BitMine Immersion Technologies Inc. Common Stock,18.88,10753610343.0,24436835,Finance
+JOBY,Joby Aviation Inc. Common Stock,10.92,10741379944.0,35927376,Industrials
+PODD,Insulet Corporation Common Stock,154.87,10727020062.0,949500,Health Care
+IT,Gartner Inc. Common Stock,160.01,10712971759.0,1042203,Consumer Discretionary
+GSAT,Globalstar Inc. Common Stock,83.0,10689481273.0,751204,Consumer Discretionary
+SCI,Service Corporation International Common Stock,77.39,10677575535.0,1263509,Consumer Discretionary
+JEF,Jefferies Financial Group Inc. Common Stock,51.98,10626391318.0,2271912,Finance
+WTRG,Essential Utilities Inc. Common Stock,37.44,10619218884.0,1154350,Utilities
+HLI,Houlihan Lokey Inc. Class A Common Stock,151.63,10581544887.0,468504,Finance
+ARWR,Arrowhead Pharmaceuticals Inc. Common Stock,74.95,10557233724.0,1401693,Health Care
+KTOS,Kratos Defense & Security Solutions Inc. Common Stock,56.18,10534872701.0,2938226,Industrials
+AM,Antero Midstream Corporation Common Stock,22.17,10530306600.0,2765748,Utilities
+DPZ,Domino's Pizza Inc Common Stock,316.52,10528047092.0,506154,Consumer Discretionary
+TTD,The Trade Desk Inc. Class A Common Stock,22.38,10521025119.0,16279162,Technology
+AES,The AES Corporation Common Stock,14.68,10469155227.0,8781130,Utilities
+BMRN,BioMarin Pharmaceutical Inc. Common Stock,54.09,10454755251.0,2438397,Health Care
+EHC,Encompass Health Corporation Common Stock,104.96,10411935437.0,668243,Health Care
+SPXC,SPX Technologies Inc. Common Stock,207.8,10403473544.0,492286,Industrials
+CR,Crane Company Common Stock,179.75,10379787059.0,374949,Industrials
+SFD,Smithfield Foods Inc. Common Stock,26.34,10364191107.0,712150,Consumer Staples
+WMS,Advanced Drainage Systems Inc. Common Stock,133.0,10360112805.0,1524822,Consumer Discretionary
+ERIE,Erie Indemnity Company Class A Common Stock,224.23,10357544710.0,188764,Finance
+FRT,Federal Realty Investment Trust Common Stock,119.75,10345106341.0,1122773,Real Estate
+HUBS,HubSpot Inc. Common Stock,201.97,10344446948.0,1302866,Technology
+POWL,Powell Industries Inc. Common Stock,279.22,10172445034.0,410031,Energy
+VSAT,ViaSat Inc. Common Stock,74.56,10127589259.0,2295213,Technology
+WTFC,Wintrust Financial Corporation Common Stock,149.89,10109744147.0,300847,Finance
+UHAL,U-Haul Holding Company Common Stock,51.55,10107814714.0,180685,Consumer Discretionary
+WTS,Watts Water Technologies Inc. Class A Common Stock,302.44,10098740772.0,231430,Industrials
+WYNN,Wynn Resorts Limited Common stock,97.24,10092221528.0,1208886,Consumer Discretionary
+BSY,Bentley Systems Incorporated Class B Common Stock,33.16,10073897710.0,1898335,Technology
+FORM,FormFactor Inc. FormFactor Inc. Common Stock,128.99,10055386040.0,1438744,Technology
+ENSG,The Ensign Group Inc. Common Stock,171.94,10049102076.0,447183,Health Care
+MUSA,Murphy USA Inc. Common Stock,542.74,10024779577.0,281362,Consumer Discretionary
+OGE,OGE Energy Corp Common Stock,48.54,10017409541.0,1042929,Utilities

--- a/yahoo_finance_api/__init__.py
+++ b/yahoo_finance_api/__init__.py
@@ -84,3 +84,7 @@ class YahooFinance:
     def to_csv(self, file_name):
         self.result.to_csv(file_name)
 
+
+from .forecast_model import ModelArtifacts, StockForecastModel, build_multi_stock_dataset
+
+from .stock_universe import download_stock_list_to_csv, fetch_us_stock_symbols, enrich_with_yahoo_metadata, enrich_with_fmp_metadata

--- a/yahoo_finance_api/forecast_model.py
+++ b/yahoo_finance_api/forecast_model.py
@@ -45,6 +45,7 @@ class StockForecastModel:
         self.data: Optional[pd.DataFrame] = None
         self.artifacts: Optional[ModelArtifacts] = None
         self._eval_cache: Optional[pd.DataFrame] = None
+        self._last_model: Optional[GradientBoostingRegressor] = None
 
     def load_raw_data(self) -> pd.DataFrame:
         stock = YahooFinance(self.stock_ticker, result_range=self.history_range, interval="1d").result
@@ -157,6 +158,7 @@ class StockForecastModel:
             r2=float(r2_score(y_test, preds)),
         )
         self.artifacts = artifacts
+        self._last_model = model
         return artifacts
 
 
@@ -213,6 +215,31 @@ class StockForecastModel:
         ax.plot([lim_low, lim_high], [lim_low, lim_high], "r--", linewidth=1)
         ax.set_title(f"{self.stock_ticker} Actual vs Predicted Scatter")
         ax.grid(alpha=0.3)
+        return ax
+
+
+    def get_feature_importance(self, top_n: int | None = None) -> pd.DataFrame:
+        """Return feature importances from the latest trained model."""
+        if self.artifacts is None or self._last_model is None:
+            self.train()
+
+        importance_df = pd.DataFrame({
+            "feature": self.artifacts.feature_columns,
+            "importance": self._last_model.feature_importances_,
+        }).sort_values("importance", ascending=False).reset_index(drop=True)
+
+        if top_n is not None:
+            return importance_df.head(top_n)
+        return importance_df
+
+    def plot_feature_importance(self, top_n: int = 20):
+        """Plot top-N feature importances from the trained model."""
+        fi = self.get_feature_importance(top_n=top_n).iloc[::-1]
+        ax = fi.plot.barh(x="feature", y="importance", figsize=(10, max(4, int(top_n * 0.35))))
+        ax.set_title(f"{self.stock_ticker} Feature Importance (Top {min(top_n, len(fi))})")
+        ax.set_xlabel("Importance")
+        ax.set_ylabel("Feature")
+        ax.grid(axis="x", alpha=0.3)
         return ax
 
     def backtest_predictions(self, min_train_size: int = 252, step: int = 1) -> pd.DataFrame:

--- a/yahoo_finance_api/forecast_model.py
+++ b/yahoo_finance_api/forecast_model.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from sklearn.ensemble import GradientBoostingRegressor
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import train_test_split
+
+from . import YahooFinance
+
+
+@dataclass
+class ModelArtifacts:
+    model: GradientBoostingRegressor
+    feature_columns: list[str]
+    train_rows: int
+    test_rows: int
+    mae: float
+    r2: float
+
+
+class StockForecastModel:
+    """Build a one-month stock price-change forecasting model.
+
+    Features include moving averages, price-weighted volume aggregates,
+    one-week and one-month momentum, and external market features from
+    gold and VIX weekly changes.
+    """
+
+    def __init__(
+        self,
+        stock_ticker: str,
+        market_cap_usd: float,
+        category_label: str,
+        history_range: str = "5y",
+    ) -> None:
+        self.stock_ticker = stock_ticker
+        self.market_cap_usd = market_cap_usd
+        self.category_label = category_label
+        self.history_range = history_range
+        self.data: Optional[pd.DataFrame] = None
+        self.artifacts: Optional[ModelArtifacts] = None
+        self._eval_cache: Optional[pd.DataFrame] = None
+
+    def load_raw_data(self) -> pd.DataFrame:
+        stock = YahooFinance(self.stock_ticker, result_range=self.history_range, interval="1d").result
+        gold = YahooFinance("GC=F", result_range=self.history_range, interval="1d").result
+        vix = YahooFinance("^VIX", result_range=self.history_range, interval="1d").result
+
+        df = stock[["Open", "High", "Low", "Close", "Volume"]].copy()
+        df["gold_close"] = gold["Close"].reindex(df.index).ffill()
+        df["vix_close"] = vix["Close"].reindex(df.index).ffill()
+        self.data = df.dropna().copy()
+        return self.data
+
+    def build_features(self) -> pd.DataFrame:
+        if self.data is None:
+            self.load_raw_data()
+
+        df = self.data.copy()
+        df["ma_20"] = df["Close"].rolling(20).mean()
+        df["ma_120"] = df["Close"].rolling(120).mean()
+        df["ma_200"] = df["Close"].rolling(200).mean()
+
+        df["price_weighted_volume"] = df["Close"] * df["Volume"]
+        df["pwv_1w"] = df["price_weighted_volume"].rolling(5).mean()
+        df["pwv_1m"] = df["price_weighted_volume"].rolling(21).mean()
+
+        df["change_1w"] = df["Close"].pct_change(5)
+        df["change_1m"] = df["Close"].pct_change(21)
+        df["gold_change_1w"] = df["gold_close"].pct_change(5)
+        df["vix_change_1w"] = df["vix_close"].pct_change(5)
+
+        df["stock_category"] = self.category_label
+        df["is_large_cap_10b"] = float(self.market_cap_usd > 10_000_000_000)
+
+        df["target_1m_price_change"] = df["Close"].shift(-21) / df["Close"] - 1
+        df = pd.get_dummies(df, columns=["stock_category"], drop_first=False)
+
+        feature_cols = [
+            "Open",
+            "High",
+            "Low",
+            "Close",
+            "Volume",
+            "ma_20",
+            "ma_120",
+            "ma_200",
+            "pwv_1w",
+            "pwv_1m",
+            "change_1w",
+            "change_1m",
+            "gold_change_1w",
+            "vix_change_1w",
+            "is_large_cap_10b",
+        ] + [c for c in df.columns if c.startswith("stock_category_")]
+
+        engineered = df[feature_cols + ["target_1m_price_change"]].dropna()
+        self.data = engineered
+        return engineered
+
+
+    def plot_historical_trend(self, window_size: int = 180):
+        """Plot historical close trend with MA5/MA20/MA120.
+
+        :param window_size: Number of most recent rows to plot.
+        :return: matplotlib Axes object
+        """
+        if self.data is None:
+            self.load_raw_data()
+
+        base = self.data[["Close"]].copy()
+        base["MA5"] = base["Close"].rolling(5).mean()
+        base["MA20"] = base["Close"].rolling(20).mean()
+        base["MA120"] = base["Close"].rolling(120).mean()
+        plot_df = base.tail(window_size).dropna()
+
+        ax = plot_df[["Close", "MA5", "MA20", "MA120"]].plot(
+            figsize=(12, 6),
+            title=f"{self.stock_ticker} Historical Trend (last {window_size} periods)"
+        )
+        ax.set_xlabel("Date")
+        ax.set_ylabel("Price")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def train(self, random_state: int = 42) -> ModelArtifacts:
+        if self.data is None or "target_1m_price_change" not in self.data.columns:
+            self.build_features()
+
+        df = self.data.copy()
+        X = df.drop(columns=["target_1m_price_change"])
+        y = df["target_1m_price_change"]
+
+        X_train, X_test, y_train, y_test = train_test_split(
+            X,
+            y,
+            test_size=0.2,
+            random_state=random_state,
+            shuffle=False,
+        )
+
+        model = GradientBoostingRegressor(random_state=random_state)
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+
+        artifacts = ModelArtifacts(
+            model=model,
+            feature_columns=list(X.columns),
+            train_rows=len(X_train),
+            test_rows=len(X_test),
+            mae=float(mean_absolute_error(y_test, preds)),
+            r2=float(r2_score(y_test, preds)),
+        )
+        self.artifacts = artifacts
+        return artifacts
+
+
+    def evaluate_performance(self, test_size: float = 0.2, random_state: int = 42) -> dict:
+        """Evaluate model with MAE and RMSE and cache prediction frame."""
+        if self.data is None or "target_1m_price_change" not in self.data.columns:
+            self.build_features()
+
+        df = self.data.copy()
+        X = df.drop(columns=["target_1m_price_change"])
+        y = df["target_1m_price_change"]
+
+        split_idx = int(len(df) * (1 - test_size))
+        X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]
+        y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]
+
+        model = GradientBoostingRegressor(random_state=random_state)
+        model.fit(X_train, y_train)
+        preds = model.predict(X_test)
+
+        eval_df = pd.DataFrame({
+            "actual": y_test.values,
+            "predicted": preds,
+        }, index=y_test.index)
+        eval_df["error"] = eval_df["predicted"] - eval_df["actual"]
+        self._eval_cache = eval_df
+
+        mae = float(mean_absolute_error(y_test, preds))
+        rmse = float(mean_squared_error(y_test, preds) ** 0.5)
+        return {"mae": mae, "rmse": rmse, "test_rows": len(y_test)}
+
+    def plot_performance(self, test_size: float = 0.2, random_state: int = 42):
+        """Plot actual vs predicted returns on the test window."""
+        if self._eval_cache is None:
+            self.evaluate_performance(test_size=test_size, random_state=random_state)
+
+        ax = self._eval_cache[["actual", "predicted"]].plot(
+            figsize=(12, 6),
+            title=f"{self.stock_ticker} Test Set: Actual vs Predicted 1-Month Return"
+        )
+        ax.set_xlabel("Date")
+        ax.set_ylabel("1-Month Return")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def plot_prediction_scatter(self, test_size: float = 0.2, random_state: int = 42):
+        """Scatter plot of actual vs predicted with y=x reference line."""
+        if self._eval_cache is None:
+            self.evaluate_performance(test_size=test_size, random_state=random_state)
+
+        ax = self._eval_cache.plot.scatter(x="actual", y="predicted", figsize=(7, 7), alpha=0.6)
+        lim_low = min(self._eval_cache["actual"].min(), self._eval_cache["predicted"].min())
+        lim_high = max(self._eval_cache["actual"].max(), self._eval_cache["predicted"].max())
+        ax.plot([lim_low, lim_high], [lim_low, lim_high], "r--", linewidth=1)
+        ax.set_title(f"{self.stock_ticker} Actual vs Predicted Scatter")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def backtest_predictions(self, min_train_size: int = 252, step: int = 1) -> pd.DataFrame:
+        """Walk-forward backtest: predict next 1-month return for each day.
+
+        Uses only historical data available up to each forecast date, then compares
+        with the realized 1-month forward return.
+        """
+        if self.data is None or "target_1m_price_change" not in self.data.columns:
+            self.build_features()
+
+        df = self.data.copy()
+        X_all = df.drop(columns=["target_1m_price_change"])
+        y_all = df["target_1m_price_change"]
+
+        records = []
+        model = GradientBoostingRegressor(random_state=42)
+
+        for i in range(min_train_size, len(df), step):
+            X_train = X_all.iloc[:i]
+            y_train = y_all.iloc[:i]
+            X_test = X_all.iloc[[i]]
+
+            model.fit(X_train, y_train)
+            pred = float(model.predict(X_test)[0])
+            actual = float(y_all.iloc[i])
+
+            records.append({
+                "date": df.index[i],
+                "predicted_1m_change": pred,
+                "actual_1m_change": actual,
+            })
+
+        backtest_df = pd.DataFrame(records).set_index("date")
+        backtest_df["prediction_error"] = backtest_df["predicted_1m_change"] - backtest_df["actual_1m_change"]
+        return backtest_df
+
+    def plot_backtest(self, min_train_size: int = 252, step: int = 1):
+        """Plot historical backtest with predicted vs actual 1-month return."""
+        backtest_df = self.backtest_predictions(min_train_size=min_train_size, step=step)
+        ax = backtest_df[["actual_1m_change", "predicted_1m_change"]].plot(
+            figsize=(12, 6),
+            title=f"{self.stock_ticker} Backtest: Actual vs Predicted 1-Month Change"
+        )
+        ax.set_xlabel("Date")
+        ax.set_ylabel("1-Month Return")
+        ax.grid(alpha=0.3)
+        return ax
+
+    def predict_latest(self) -> float:
+        if self.artifacts is None:
+            raise RuntimeError("Call train() before predict_latest().")
+
+        latest = self.data[self.artifacts.feature_columns].tail(1)
+        return float(self.artifacts.model.predict(latest)[0])
+
+
+def build_multi_stock_dataset(configs: Iterable[dict], history_range: str = "5y") -> pd.DataFrame:
+    """Create a combined dataset across several stocks in the same category schema.
+
+    Each config should include: ticker, market_cap_usd, category_label.
+    """
+
+    frames: list[pd.DataFrame] = []
+    for cfg in configs:
+        model = StockForecastModel(
+            stock_ticker=cfg["ticker"],
+            market_cap_usd=float(cfg["market_cap_usd"]),
+            category_label=cfg["category_label"],
+            history_range=history_range,
+        )
+        frames.append(model.build_features())
+
+    return pd.concat(frames, axis=0).dropna()

--- a/yahoo_finance_api/stock_universe.py
+++ b/yahoo_finance_api/stock_universe.py
@@ -10,8 +10,8 @@ import requests
 NASDAQ_LISTED_URL = "https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt"
 OTHER_LISTED_URL = "https://www.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt"
 YAHOO_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
-FMP_PROFILE_URL = "https://financialmodelingprep.com/api/v3/profile"
-
+# FMP_PROFILE_URL = "https://financialmodelingprep.com/api/v3/profile"
+FMP_PROFILE_URL = "https://financialmodelingprep.com/stable/profile?symbol="
 
 def _read_symbol_file(url: str, symbol_col: str) -> pd.DataFrame:
     response = requests.get(url, timeout=30)
@@ -90,7 +90,7 @@ def enrich_with_yahoo_metadata(symbols_df: pd.DataFrame, batch_size: int = 200) 
     return merged
 
 
-def enrich_with_fmp_metadata(symbols_df: pd.DataFrame, api_key: str | None = None, batch_size: int = 100) -> pd.DataFrame:
+def enrich_with_fmp_metadata(symbols_df: pd.DataFrame, api_key: str | None = None, batch_size: int = 1) -> pd.DataFrame:
     """Add market cap and category from Financial Modeling Prep profiles API."""
     resolved_key = api_key or os.getenv("FMP_API_KEY")
     if not resolved_key:
@@ -99,7 +99,8 @@ def enrich_with_fmp_metadata(symbols_df: pd.DataFrame, api_key: str | None = Non
     records: list[dict] = []
     for batch in _chunks(symbols_df["symbol"].tolist(), batch_size):
         symbols = ",".join(batch)
-        url = f"{FMP_PROFILE_URL}/{symbols}"
+        url = f"{FMP_PROFILE_URL}{symbols}"
+        # print(url)
         try:
             response = requests.get(url, params={"apikey": resolved_key}, timeout=30)
             response.raise_for_status()

--- a/yahoo_finance_api/stock_universe.py
+++ b/yahoo_finance_api/stock_universe.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import os
+import time
+from typing import Iterable
+
+import pandas as pd
+import requests
+
+NASDAQ_LISTED_URL = "https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt"
+OTHER_LISTED_URL = "https://www.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt"
+YAHOO_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
+FMP_PROFILE_URL = "https://financialmodelingprep.com/api/v3/profile"
+
+
+def _read_symbol_file(url: str, symbol_col: str) -> pd.DataFrame:
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    lines = [line.strip() for line in response.text.splitlines() if line.strip()]
+    header = lines[0].split("|")
+    rows = [line.split("|") for line in lines[1:] if not line.startswith("File Creation Time")]
+    return pd.DataFrame(rows, columns=header)
+
+
+def fetch_us_stock_symbols() -> pd.DataFrame:
+    """Fetch a broad US stock symbol list from NASDAQ Trader directories."""
+    nasdaq = _read_symbol_file(NASDAQ_LISTED_URL, "Symbol")
+    nasdaq = nasdaq.rename(columns={"Symbol": "symbol", "Security Name": "security_name"})
+    nasdaq["exchange"] = "NASDAQ"
+
+    other = _read_symbol_file(OTHER_LISTED_URL, "ACT Symbol")
+    other = other.rename(columns={"ACT Symbol": "symbol", "Security Name": "security_name", "Exchange": "exchange"})
+
+    combined = pd.concat([
+        nasdaq[["symbol", "security_name", "exchange"]],
+        other[["symbol", "security_name", "exchange"]],
+    ], ignore_index=True)
+    combined = combined[~combined["symbol"].str.contains(r"\$", regex=True, na=False)]
+    return combined.drop_duplicates(subset=["symbol"]).reset_index(drop=True)
+
+
+def _chunks(items: Iterable[str], size: int):
+    items = list(items)
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+def _safe_fetch_yahoo_batch(batch: list[str], headers: dict, retries: int = 3) -> list[dict]:
+    params = {"symbols": ",".join(batch)}
+    delay = 1.0
+    for attempt in range(retries):
+        try:
+            response = requests.get(YAHOO_QUOTE_URL, params=params, headers=headers, timeout=30)
+            if response.status_code == 401:
+                return []
+            response.raise_for_status()
+            return response.json().get("quoteResponse", {}).get("result", [])
+        except requests.RequestException:
+            if attempt == retries - 1:
+                return []
+            time.sleep(delay)
+            delay *= 2
+    return []
+
+
+def enrich_with_yahoo_metadata(symbols_df: pd.DataFrame, batch_size: int = 200) -> pd.DataFrame:
+    records = []
+    headers = {"User-Agent": "Mozilla/5.0"}
+    for batch in _chunks(symbols_df["symbol"].tolist(), batch_size):
+        result = _safe_fetch_yahoo_batch(batch, headers=headers)
+        if not result and len(batch) > 1:
+            for sym in batch:
+                one = _safe_fetch_yahoo_batch([sym], headers=headers)
+                if one:
+                    result.extend(one)
+                time.sleep(0.05)
+        for item in result:
+            records.append({
+                "symbol": item.get("symbol"),
+                "market_cap": item.get("marketCap"),
+                "sector": item.get("sector"),
+                "industry": item.get("industry"),
+                "quote_type": item.get("quoteType"),
+                "meta_source": "yahoo",
+            })
+
+    meta = pd.DataFrame(records).drop_duplicates(subset=["symbol"]) if records else pd.DataFrame(columns=["symbol", "market_cap", "sector", "industry", "quote_type", "meta_source"])
+    merged = symbols_df.merge(meta, on="symbol", how="left")
+    merged["stock_category"] = merged["sector"].fillna("Unknown")
+    return merged
+
+
+def enrich_with_fmp_metadata(symbols_df: pd.DataFrame, api_key: str | None = None, batch_size: int = 100) -> pd.DataFrame:
+    """Add market cap and category from Financial Modeling Prep profiles API."""
+    resolved_key = api_key or os.getenv("FMP_API_KEY")
+    if not resolved_key:
+        raise ValueError("FMP API key is required. Pass api_key or set FMP_API_KEY env var.")
+
+    records: list[dict] = []
+    for batch in _chunks(symbols_df["symbol"].tolist(), batch_size):
+        symbols = ",".join(batch)
+        url = f"{FMP_PROFILE_URL}/{symbols}"
+        try:
+            response = requests.get(url, params={"apikey": resolved_key}, timeout=30)
+            response.raise_for_status()
+            result = response.json()
+            if not isinstance(result, list):
+                result = []
+        except requests.RequestException:
+            result = []
+
+        for item in result:
+            records.append({
+                "symbol": item.get("symbol"),
+                "market_cap": item.get("mktCap"),
+                "sector": item.get("sector"),
+                "industry": item.get("industry"),
+                "quote_type": item.get("ipoDate"),
+                "meta_source": "fmp",
+            })
+        time.sleep(0.1)
+
+    meta = pd.DataFrame(records).drop_duplicates(subset=["symbol"]) if records else pd.DataFrame(columns=["symbol", "market_cap", "sector", "industry", "quote_type", "meta_source"])
+    merged = symbols_df.merge(meta, on="symbol", how="left")
+    merged["stock_category"] = merged["sector"].fillna("Unknown")
+    return merged
+
+
+def download_stock_list_to_csv(
+    output_csv: str = "latest_us_stock_list.csv",
+    metadata_source: str = "yahoo",
+    fmp_api_key: str | None = None,
+) -> pd.DataFrame:
+    """Download latest stock list + market size + stock category and save to CSV.
+
+    metadata_source: "yahoo" or "fmp".
+    """
+    symbols = fetch_us_stock_symbols()
+    source = metadata_source.lower().strip()
+    if source == "yahoo":
+        enriched = enrich_with_yahoo_metadata(symbols)
+    elif source == "fmp":
+        enriched = enrich_with_fmp_metadata(symbols, api_key=fmp_api_key)
+    else:
+        raise ValueError("Unsupported metadata_source. Use 'yahoo' or 'fmp'.")
+
+    enriched.to_csv(output_csv, index=False)
+    return enriched


### PR DESCRIPTION
### Motivation

- Provide a reusable 1-month stock return forecasting model and a standalone example so users can train, predict, backtest, and visualize forecasts. 
- Add utilities to fetch and enrich a US stock symbol universe with market cap and sector metadata to support multi-stock datasets. 
- Expose forecasting APIs from the package and expand the README with usage and examples. 

### Description

- Added a `StockForecastModel` implementation (in `yahoo_finance_api/forecast_model.py` and a standalone copy under `standalone_stock_forecast/`) that builds engineered features, trains a `GradientBoostingRegressor`, evaluates MAE/RMSE/R2, supports plotting, and includes a walk-forward backtester. 
- Implemented `stock_universe.py` to fetch NASDAQ/other listed symbols, enrich metadata via Yahoo or Financial Modeling Prep, and save a CSV via `download_stock_list_to_csv`. 
- Added a lightweight `YahooFinanceClient` for standalone usage and updated package exports in `yahoo_finance_api/__init__.py` to re-export `ModelArtifacts`, `StockForecastModel`, `build_multi_stock_dataset`, and stock-universe helpers. 
- Added a standalone example project (`standalone_stock_forecast/`) with `forecast_model.py`, `yahoo_client.py`, `train_example.py`, `stock_list_downloader.py`, and `requirements.txt`, and updated the top-level `README.md` with model examples, plotting, backtest, and downloader usage. 
- Minor fix in existing package `__init__` datetime parsing and added type hints and dataclasses for clearer artifacts handling. 

### Testing

- No new unit test suite was added as part of this change. 
- Performed a smoke import test with `python -c "import yahoo_finance_api"` which succeeded. 
- Ran the standalone example `python standalone_stock_forecast/train_example.py` as a quick end-to-end smoke run to exercise training and prediction, which completed without errors on the local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a134d8f7c50832ba99ec838ad86a0c3)